### PR TITLE
Support setting no_pivot_root for create and run command

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -48,6 +48,8 @@ pub(super) struct ContainerBuilderImpl {
     pub detached: bool,
     /// Default executes the specified execution of a generic command
     pub executor: Box<dyn Executor>,
+    /// If do not use pivot root to jail process inside rootfs
+    pub no_pivot: bool,
 }
 
 impl ContainerBuilderImpl {
@@ -148,6 +150,7 @@ impl ContainerBuilderImpl {
             cgroup_config,
             detached: self.detached,
             executor: self.executor.clone(),
+            no_pivot: self.no_pivot,
         };
 
         let (init_pid, need_to_clean_up_intel_rdt_dir) =

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -26,6 +26,7 @@ pub struct InitContainerBuilder {
     bundle: PathBuf,
     use_systemd: bool,
     detached: bool,
+    no_pivot: bool,
 }
 
 impl InitContainerBuilder {
@@ -37,6 +38,7 @@ impl InitContainerBuilder {
             bundle,
             use_systemd: true,
             detached: true,
+            no_pivot: false,
         }
     }
 
@@ -48,6 +50,11 @@ impl InitContainerBuilder {
 
     pub fn with_detach(mut self, detached: bool) -> Self {
         self.detached = detached;
+        self
+    }
+
+    pub fn with_no_pivot(mut self, no_pivot: bool) -> Self {
+        self.no_pivot = no_pivot;
         self
     }
 
@@ -109,6 +116,7 @@ impl InitContainerBuilder {
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
             executor: self.base.executor,
+            no_pivot: self.no_pivot,
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -141,6 +141,7 @@ impl TenantContainerBuilder {
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
             executor: self.base.executor,
+            no_pivot: false,
         };
 
         let pid = builder_impl.create()?;

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -41,4 +41,6 @@ pub struct ContainerArgs {
     pub detached: bool,
     /// Manage the functions that actually run on the container
     pub executor: Box<dyn Executor>,
+    /// If do not use pivot root to jail process inside rootfs
+    pub no_pivot: bool,
 }

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -331,7 +331,7 @@ pub fn container_init_process(
         // we use pivot_root, but if we are on the host mount namespace, we will
         // use simple chroot. Scary things will happen if you try to pivot_root
         // in the host mount namespace...
-        if namespaces.get(LinuxNamespaceType::Mount)?.is_some() {
+        if namespaces.get(LinuxNamespaceType::Mount)?.is_some() && !args.no_pivot {
             // change the root of filesystem of the process to the rootfs
             syscall.pivot_rootfs(rootfs_path).map_err(|err| {
                 tracing::error!(?err, ?rootfs_path, "failed to pivot root");

--- a/crates/youki/src/commands/create.rs
+++ b/crates/youki/src/commands/create.rs
@@ -23,6 +23,7 @@ pub fn create(args: Create, root_path: PathBuf, systemd_cgroup: bool) -> Result<
         .as_init(&args.bundle)
         .with_systemd(systemd_cgroup)
         .with_detach(true)
+        .with_no_pivot(args.no_pivot)
         .build()?;
 
     Ok(())

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -25,6 +25,7 @@ pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
         .as_init(&args.bundle)
         .with_systemd(systemd_cgroup)
         .with_detach(args.detach)
+        .with_no_pivot(args.no_pivot)
         .build()?;
 
     container


### PR DESCRIPTION
This pr supports setting no_pivot_root for create and run command,
what no_pivot means refer to https://github.com/opencontainers/runc/blob/main/man/runc-create.8.md
As pivot_root could not work with initramfs, youki create failed when container rootfs is on initramfs, so supporting to disable it and replace with chroot is needed.