### PR TITLE
Support setting stdin, stdout and stderr

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -307,7 +307,7 @@ fn prepare_stdio_descriptors(fds: &[Fd; 3]) -> Result<StdioDescriptors, Libconta
                     OFlag::O_CLOEXEC | OFlag::O_RDONLY,
                     Mode::empty(),
                 )
-                .map_err(PipeError::Create)?;
+                .map_err(PipeError::Open)?;
                 guards.push(Closing::new(fd));
                 fd
             }
@@ -318,7 +318,7 @@ fn prepare_stdio_descriptors(fds: &[Fd; 3]) -> Result<StdioDescriptors, Libconta
                     OFlag::O_CLOEXEC | OFlag::O_WRONLY,
                     Mode::empty(),
                 )
-                .map_err(PipeError::Create)?;
+                .map_err(PipeError::Open)?;
                 guards.push(Closing::new(fd));
                 fd
             }
@@ -327,8 +327,8 @@ fn prepare_stdio_descriptors(fds: &[Fd; 3]) -> Result<StdioDescriptors, Libconta
         };
         // The descriptor must not clobber the descriptors that are passed to
         // a child
-        while fd != dest_fd {
-            fd = fcntl(fd, FcntlArg::F_DUPFD_CLOEXEC(3)).map_err(PipeError::Create)?;
+        while fd != dest_fd && fd < 3 {
+            fd = fcntl(fd, FcntlArg::F_DUPFD_CLOEXEC(3)).map_err(PipeError::Dup)?;
             guards.push(Closing::new(fd));
         }
         inner.insert(dest_fd, fd);

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -17,7 +17,8 @@ use crate::{
 };
 
 use super::{
-    builder::ContainerBuilder, builder_impl::ContainerBuilderImpl, Container, ContainerStatus,
+    builder::ContainerBuilder, builder_impl::ContainerBuilderImpl, stdio::StdioFds, Container,
+    ContainerStatus,
 };
 
 // Builder that can be used to configure the properties of a new container
@@ -52,7 +53,7 @@ impl InitContainerBuilder {
     }
 
     /// Creates a new container
-    pub fn build(self) -> Result<Container, LibcontainerError> {
+    pub fn build(self) -> Result<(Container, StdioFds), LibcontainerError> {
         let spec = self.load_spec()?;
         let container_dir = self.create_container_dir()?;
 
@@ -109,13 +110,14 @@ impl InitContainerBuilder {
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
             executor: self.base.executor,
+            fds: self.base.fds,
         };
 
-        builder_impl.create()?;
+        let (_, stdio_fds) = builder_impl.create()?;
 
         container.refresh_state()?;
 
-        Ok(container)
+        Ok((container, stdio_fds))
     }
 
     fn create_container_dir(&self) -> Result<PathBuf, LibcontainerError> {

--- a/crates/libcontainer/src/container/mod.rs
+++ b/crates/libcontainer/src/container/mod.rs
@@ -17,6 +17,7 @@ mod container_resume;
 mod container_start;
 pub mod init_builder;
 pub mod state;
+pub mod stdio;
 pub mod tenant_builder;
 pub use container::CheckpointOptions;
 pub use container::Container;

--- a/crates/libcontainer/src/container/stdio.rs
+++ b/crates/libcontainer/src/container/stdio.rs
@@ -1,0 +1,7 @@
+use crate::pipe::{PipeReader, PipeWriter};
+
+pub struct StdioFds {
+    pub stdin: Option<PipeWriter>,
+    pub stdout: Option<PipeReader>,
+    pub stderr: Option<PipeReader>,
+}

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -107,8 +107,6 @@ impl TenantContainerBuilder {
         let mut spec = self.load_init_spec(&container)?;
         self.adapt_spec_for_tenant(&mut spec, &container)?;
 
-        tracing::debug!("{:#?}", spec);
-
         unistd::chdir(&container_dir).map_err(LibcontainerError::OtherSyscall)?;
         let notify_path = Self::setup_notify_listener(&container_dir)?;
         // convert path of root file system of the container to absolute path

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -25,6 +25,7 @@ use crate::process::args::ContainerType;
 use crate::{capabilities::CapabilityExt, container::builder_impl::ContainerBuilderImpl};
 use crate::{notify_socket::NotifySocket, tty, user_ns::UserNamespaceConfig, utils};
 
+use super::stdio::StdioFds;
 use super::{builder::ContainerBuilder, Container};
 
 const NAMESPACE_TYPES: &[&str] = &["ipc", "uts", "net", "pid", "mnt", "cgroup"];
@@ -100,7 +101,7 @@ impl TenantContainerBuilder {
     }
 
     /// Joins an existing container
-    pub fn build(self) -> Result<Pid, LibcontainerError> {
+    pub fn build(self) -> Result<(Pid, StdioFds), LibcontainerError> {
         let container_dir = self.lookup_container_dir()?;
         let container = self.load_container_state(container_dir.clone())?;
         let mut spec = self.load_init_spec(&container)?;
@@ -141,6 +142,7 @@ impl TenantContainerBuilder {
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
             executor: self.base.executor,
+            fds: self.base.fds,
         };
 
         let pid = builder_impl.create()?;

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -37,6 +37,8 @@ pub enum LibcontainerError {
     #[error(transparent)]
     Tty(#[from] crate::tty::TTYError),
     #[error(transparent)]
+    Pipe(#[from] crate::pipe::PipeError),
+    #[error(transparent)]
     UserNamespace(#[from] crate::user_ns::UserNamespaceError),
     #[error(transparent)]
     NotifyListener(#[from] crate::notify_socket::NotifyListenerError),

--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -7,11 +7,13 @@ pub mod error;
 pub mod hooks;
 pub mod namespaces;
 pub mod notify_socket;
+pub mod pipe;
 pub mod process;
 pub mod rootfs;
 #[cfg(feature = "libseccomp")]
 pub mod seccomp;
 pub mod signal;
+pub mod stdio;
 pub mod syscall;
 pub mod test_utils;
 pub mod tty;

--- a/crates/libcontainer/src/pipe.rs
+++ b/crates/libcontainer/src/pipe.rs
@@ -29,6 +29,10 @@ pub enum PipeHolder {
 pub enum PipeError {
     #[error("failed to create pipe: {0}")]
     Create(nix::Error),
+    #[error("failed to open fd: {0}")]
+    Open(nix::Error),
+    #[error("failed to dup fd: {0}")]
+    Dup(nix::Error),
 }
 
 impl Pipe {

--- a/crates/libcontainer/src/pipe.rs
+++ b/crates/libcontainer/src/pipe.rs
@@ -1,0 +1,111 @@
+use std::io;
+use std::mem;
+use std::os::unix::io::RawFd;
+
+use libc;
+use libc::{c_void, size_t};
+use nix::fcntl::OFlag;
+use nix::unistd::pipe2;
+
+/// A pipe used to communicate with subprocess
+#[derive(Debug)]
+pub struct Pipe(RawFd, RawFd);
+
+/// A reading end of `Pipe` object after `Pipe::split`
+#[derive(Debug)]
+pub struct PipeReader(RawFd);
+
+/// A writing end of `Pipe` object after `Pipe::split`
+#[derive(Debug)]
+pub struct PipeWriter(RawFd);
+
+#[derive(Debug)]
+pub enum PipeHolder {
+    Reader(PipeReader),
+    Writer(PipeWriter),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PipeError {
+    #[error("failed to create pipe: {0}")]
+    Create(nix::Error),
+}
+
+impl Pipe {
+    pub fn new() -> Result<Pipe, PipeError> {
+        let (rd, wr) = pipe2(OFlag::O_CLOEXEC).map_err(PipeError::Create)?;
+        Ok(Pipe(rd, wr))
+    }
+    pub fn split(self) -> (PipeReader, PipeWriter) {
+        let Pipe(rd, wr) = self;
+        mem::forget(self);
+        (PipeReader(rd), PipeWriter(wr))
+    }
+}
+
+impl Drop for Pipe {
+    fn drop(&mut self) {
+        let Pipe(x, y) = *self;
+        unsafe {
+            libc::close(x);
+            libc::close(y);
+        }
+    }
+}
+
+impl PipeReader {
+    /// Extract file descriptor from pipe reader without closing
+    // TODO(tailhook) implement IntoRawFd here
+    pub fn into_fd(self) -> RawFd {
+        let PipeReader(fd) = self;
+        mem::forget(self);
+        fd
+    }
+}
+
+impl PipeWriter {
+    /// Extract file descriptor from pipe reader without closing
+    // TODO(tailhook) implement IntoRawFd her
+    pub fn into_fd(self) -> RawFd {
+        let PipeWriter(fd) = self;
+        mem::forget(self);
+        fd
+    }
+}
+
+impl Drop for PipeReader {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.0) };
+    }
+}
+
+impl Drop for PipeWriter {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.0) };
+    }
+}
+
+impl io::Read for PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let ret =
+            unsafe { libc::read(self.0, buf.as_mut_ptr() as *mut c_void, buf.len() as size_t) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(ret as usize)
+    }
+}
+
+impl io::Write for PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let ret =
+            unsafe { libc::write(self.0, buf.as_ptr() as *const c_void, buf.len() as size_t) };
+        if ret < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(ret as usize)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -1,5 +1,6 @@
 use libcgroups::common::CgroupConfig;
 use oci_spec::runtime::Spec;
+use std::collections::HashMap;
 use std::os::unix::prelude::RawFd;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -41,4 +42,6 @@ pub struct ContainerArgs {
     pub detached: bool,
     /// Manage the functions that actually run on the container
     pub executor: Box<dyn Executor>,
+
+    pub fds: HashMap<RawFd, RawFd>,
 }

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -560,7 +560,7 @@ pub fn container_init_process(
         }
     }
     #[cfg(not(feature = "libseccomp"))]
-    if proc.no_new_privileges().is_none() {
+    if proc.no_new_privileges().unwrap_or_default() {
         tracing::warn!("seccomp not available, unable to enforce no_new_privileges!")
     }
 
@@ -621,7 +621,7 @@ pub fn container_init_process(
         }
     }
     #[cfg(not(feature = "libseccomp"))]
-    if proc.no_new_privileges().is_some() {
+    if proc.no_new_privileges().unwrap_or_default() {
         tracing::warn!("seccomp not available, unable to set seccomp privileges!")
     }
 

--- a/crates/libcontainer/src/stdio.rs
+++ b/crates/libcontainer/src/stdio.rs
@@ -1,0 +1,146 @@
+// Code mostly copied from the `unshare` crate.
+
+use std::io;
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+
+use nix::fcntl::{fcntl, FcntlArg};
+
+/// An enumeration that is used to configure stdio file descritors
+///
+/// The enumeration members might be non-stable, it's better to use
+/// one of the constructors to create an instance
+#[derive(Default)]
+pub enum Stdio {
+    /// This fd will be inherited from the parent application
+    #[default]
+    Inherit,
+    /// This fd will use pipe to/from the appliation
+    Pipe,
+    /// This fd will open /dev/null in read or write mode
+    Null,
+    /// This is fd passed by application (and closed by `unshare`)
+    Fd(Closing),
+}
+
+/// An enumeration that is used to configure non-stdio file descriptors. It
+/// differs from stdio one because we must differentiate from readable and
+/// writable file descriptors for things open by the library
+///
+/// The enumeration members might be non-stable, it's better to use
+/// one of the constructors to create an instance
+pub enum Fd {
+    /// This fd is a reading end of a pipe
+    ReadPipe,
+    /// This fd is a writing end of a pipe
+    WritePipe,
+    /// This fd is inherited from parent (current) process
+    Inherit,
+    /// This fd is redirected from `/dev/null`
+    ReadNull,
+    /// This fd is redirected to `/dev/null`
+    WriteNull,
+    /// This is fd passed by application (and closed by `unshare`)
+    Fd(Closing),
+}
+
+pub struct Closing(RawFd);
+
+pub fn dup_file_cloexec<F: AsRawFd>(file: &F) -> io::Result<Closing> {
+    match fcntl(file.as_raw_fd(), FcntlArg::F_DUPFD_CLOEXEC(3)) {
+        Ok(fd) => Ok(Closing::new(fd)),
+        Err(errno) => Err(io::Error::from_raw_os_error(errno as i32)),
+    }
+}
+
+impl Stdio {
+    /// Pipe is created for child process
+    pub fn piped() -> Stdio {
+        Stdio::Pipe
+    }
+    /// The child inherits file descriptor from the parent process
+    pub fn inherit() -> Stdio {
+        Stdio::Inherit
+    }
+    /// Stream is attached to `/dev/null`
+    pub fn null() -> Stdio {
+        Stdio::Null
+    }
+    /// Converts stdio definition to file descriptor definition
+    /// (mostly needed internally)
+    pub fn to_fd(self, write: bool) -> Fd {
+        match (self, write) {
+            (Stdio::Fd(x), _) => Fd::Fd(x),
+            (Stdio::Pipe, false) => Fd::ReadPipe,
+            (Stdio::Pipe, true) => Fd::WritePipe,
+            (Stdio::Inherit, _) => Fd::Inherit,
+            (Stdio::Null, false) => Fd::ReadNull,
+            (Stdio::Null, true) => Fd::WriteNull,
+        }
+    }
+    /// A simpler helper method for `from_raw_fd`, that does dup of file
+    /// descriptor, so is actually safe to use (but can fail)
+    pub fn dup_file<F: AsRawFd>(file: &F) -> io::Result<Stdio> {
+        dup_file_cloexec(file).map(Stdio::Fd)
+    }
+    /// A simpler helper method for `from_raw_fd`, that consumes file
+    ///
+    /// Note: we assume that file descriptor **already has** the `CLOEXEC`
+    /// flag. This is by default for all files opened by rust.
+    pub fn from_file<F: IntoRawFd>(file: F) -> Stdio {
+        Stdio::Fd(Closing(file.into_raw_fd()))
+    }
+}
+
+impl Fd {
+    /// Create a pipe so that child can read from it
+    pub fn piped_read() -> Fd {
+        Fd::ReadPipe
+    }
+    /// Create a pipe so that child can write to it
+    pub fn piped_write() -> Fd {
+        Fd::WritePipe
+    }
+    /// Inherit the child descriptor from parent
+    ///
+    /// Not very useful for custom file descriptors better use `from_file()`
+    pub fn inherit() -> Fd {
+        Fd::Inherit
+    }
+    /// Create a readable pipe that always has end of file condition
+    pub fn read_null() -> Fd {
+        Fd::ReadNull
+    }
+    /// Create a writable pipe that ignores all the input
+    pub fn write_null() -> Fd {
+        Fd::WriteNull
+    }
+    /// A simpler helper method for `from_raw_fd`, that does dup of file
+    /// descriptor, so is actually safe to use (but can fail)
+    pub fn dup_file<F: AsRawFd>(file: &F) -> io::Result<Fd> {
+        dup_file_cloexec(file).map(Fd::Fd)
+    }
+    /// A simpler helper method for `from_raw_fd`, that consumes file
+    pub fn from_file<F: IntoRawFd>(file: F) -> Fd {
+        Fd::Fd(Closing(file.into_raw_fd()))
+    }
+}
+
+impl Closing {
+    pub fn new(fd: RawFd) -> Closing {
+        Closing(fd)
+    }
+}
+
+impl AsRawFd for Closing {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+impl Drop for Closing {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.0);
+        }
+    }
+}

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -8,7 +8,7 @@ use liboci_cli::Exec;
 use crate::workload::executor::default_executor;
 
 pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
-    let pid = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
+    let (pid, _) = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
         .with_executor(default_executor())
         .with_root_path(root_path)?
         .with_console_socket(args.console_socket.as_ref())

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -15,17 +15,18 @@ use nix::{
 use crate::workload::executor::default_executor;
 
 pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
-    let mut container = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
-        .with_executor(default_executor())
-        .with_pid_file(args.pid_file.as_ref())?
-        .with_console_socket(args.console_socket.as_ref())
-        .with_root_path(root_path)?
-        .with_preserved_fds(args.preserve_fds)
-        .validate_id()?
-        .as_init(&args.bundle)
-        .with_systemd(systemd_cgroup)
-        .with_detach(args.detach)
-        .build()?;
+    let (mut container, _) =
+        ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
+            .with_executor(default_executor())
+            .with_pid_file(args.pid_file.as_ref())?
+            .with_console_socket(args.console_socket.as_ref())
+            .with_root_path(root_path)?
+            .with_preserved_fds(args.preserve_fds)
+            .validate_id()?
+            .as_init(&args.bundle)
+            .with_systemd(systemd_cgroup)
+            .with_detach(args.detach)
+            .build()?;
 
     container
         .start()


### PR DESCRIPTION
(This is a little rough and I'm happy to make changes.)

We're using `libcontainer` from a single process and we need to be able to set stdio specifically for each forked / cloned process running as containers. Usually each container is also its own invocation of `youki` and stdio is inherit. Therefore the spawner can set their own stdio file descriptors for the spawned `youki` process. That's not the case for us.

This adds a few functions to set `stdin`, `stdout` and `stderr` as either `Inherit` (default), `Null`, `Pipe` or a specific `Fd`.

It is a breaking change for `libcontainer` since the return values have changed. This is because we can't clone `PipeReader`, `PipeWriter` or `Closing` as they need to close a file descriptor on `Drop`.