### PR TITLE
Fix --preserve-fds, eliminate stray FD being passed into container

### DIFF
--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -580,6 +580,9 @@ pub fn container_init_process(
     // will be closed after execve into the container payload. We can't close the
     // fds immediately since we at least still need it for the pipe used to wait on
     // starting the container.
+    //
+    // Note: this should happen very late, in order to avoid accidentally leaking FDs
+    // Please refer to https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv for more details.
     syscall.close_range(preserve_fds).map_err(|err| {
         tracing::error!(?err, "failed to cleanup extra fds");
         InitProcessError::SyscallOther(err)

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -75,15 +75,6 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
         })
     };
 
-    // Before starting the intermediate process, mark all non-stdio open files as O_CLOEXEC
-    // to ensure we don't leak any file descriptors to the intermediate process.
-    // Please refer to https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv for more details.
-    let syscall = container_args.syscall.create_syscall();
-    syscall.close_range(0).map_err(|err| {
-        tracing::error!(?err, "failed to cleanup extra fds");
-        ProcessError::SyscallOther(err)
-    })?;
-
     let intermediate_pid = fork::container_clone(cb).map_err(|err| {
         tracing::error!("failed to fork intermediate process: {}", err);
         ProcessError::IntermediateProcessFailed(err)

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -12,6 +12,7 @@ use tests::cgroups;
 use crate::tests::devices::get_devices_test;
 use crate::tests::domainname::get_domainname_tests;
 use crate::tests::example::get_example_test;
+use crate::tests::fd_control::get_fd_control_test;
 use crate::tests::hooks::get_hooks_tests;
 use crate::tests::hostname::get_hostname_test;
 use crate::tests::intel_rdt::get_intel_rdt_test;
@@ -125,6 +126,7 @@ fn main() -> Result<()> {
     let process_rlimtis = get_process_rlimits_test();
     let no_pivot = get_no_pivot_test();
     let process_oom_score_adj = get_process_oom_score_adj_test();
+    let fd_control = get_fd_control_test();
 
     tm.add_test_group(Box::new(cl));
     tm.add_test_group(Box::new(cc));
@@ -154,6 +156,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(process_rlimtis));
     tm.add_test_group(Box::new(no_pivot));
     tm.add_test_group(Box::new(process_oom_score_adj));
+    tm.add_test_group(Box::new(fd_control));
 
     tm.add_test_group(Box::new(io_priority_test));
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));

--- a/tests/contest/contest/src/tests/fd_control/mod.rs
+++ b/tests/contest/contest/src/tests/fd_control/mod.rs
@@ -1,0 +1,107 @@
+use std::fs;
+use std::os::fd::{AsRawFd, RawFd};
+
+use anyhow::{anyhow, Context, Result};
+use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
+use test_framework::{test_result, Test, TestGroup, TestResult};
+
+use crate::utils::{test_inside_container, CreateOptions};
+
+fn create_spec() -> Result<Spec> {
+    SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(
+                    ["runtimetest", "fd_control"]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<String>>(),
+                )
+                .build()?,
+        )
+        .build()
+        .context("failed to create spec")
+}
+
+fn open_devnull_no_cloexec() -> Result<(fs::File, RawFd)> {
+    // Rust std by default sets cloexec, so we undo it
+    let devnull = fs::File::open("/dev/null")?;
+    let devnull_fd = devnull.as_raw_fd();
+    let flags = nix::fcntl::fcntl(devnull_fd, nix::fcntl::FcntlArg::F_GETFD)?;
+    let mut flags = nix::fcntl::FdFlag::from_bits_retain(flags);
+    flags.remove(nix::fcntl::FdFlag::FD_CLOEXEC);
+    nix::fcntl::fcntl(devnull_fd, nix::fcntl::FcntlArg::F_SETFD(flags))?;
+    Ok((devnull, devnull_fd))
+}
+
+// If not opening any other FDs, verify youki itself doesnt open anything that gets
+// leaked in if passing --preserve-fds with a large number
+// NOTE: this will also fail if the test harness itself starts leaking FDs
+fn only_stdio_test() -> TestResult {
+    let spec = test_result!(create_spec());
+    test_inside_container(
+        spec,
+        &CreateOptions::default().with_extra_args(&["--preserve-fds".as_ref(), "100".as_ref()]),
+        &|bundle_path| {
+            fs::write(bundle_path.join("num-fds"), "0".as_bytes())?;
+            Ok(())
+        },
+    )
+}
+
+// If we know we have an open FD without cloexec, it should be closed if preserve-fds
+// is 0 (the default)
+fn closes_fd_test() -> TestResult {
+    // Open this before the setup function so it's kept alive for the container lifetime
+    let (_devnull, _devnull_fd) = match open_devnull_no_cloexec() {
+        Ok(v) => v,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open dev null: {}", e)),
+    };
+
+    let spec = test_result!(create_spec());
+    test_inside_container(
+        spec,
+        &CreateOptions::default().with_extra_args(&["--preserve-fds".as_ref(), "0".as_ref()]),
+        &|bundle_path| {
+            fs::write(bundle_path.join("num-fds"), "0".as_bytes())?;
+            Ok(())
+        },
+    )
+}
+
+// Given an open FD, verify it can be passed down with preserve-fds
+fn pass_single_fd_test() -> TestResult {
+    // Open this before the setup function so it's kept alive for the container lifetime
+    let (_devnull, devnull_fd) = match open_devnull_no_cloexec() {
+        Ok(v) => v,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open dev null: {}", e)),
+    };
+
+    let spec = test_result!(create_spec());
+    test_inside_container(
+        spec,
+        &CreateOptions::default().with_extra_args(&[
+            "--preserve-fds".as_ref(),
+            (devnull_fd - 2).to_string().as_ref(), // relative to stdio
+        ]),
+        &|bundle_path| {
+            fs::write(bundle_path.join("num-fds"), "1".as_bytes())?;
+            Ok(())
+        },
+    )
+}
+
+pub fn get_fd_control_test() -> TestGroup {
+    let mut test_group = TestGroup::new("fd_control");
+    test_group.set_nonparallel(); // fds are process-wide state
+    let test_only_stdio = Test::new("only_stdio", Box::new(only_stdio_test));
+    let test_closes_fd = Test::new("closes_fd", Box::new(closes_fd_test));
+    let test_pass_single_fd = Test::new("pass_single_fd", Box::new(pass_single_fd_test));
+    test_group.add(vec![
+        Box::new(test_only_stdio),
+        Box::new(test_closes_fd),
+        Box::new(test_pass_single_fd),
+    ]);
+
+    test_group
+}

--- a/tests/contest/contest/src/tests/fd_control/mod.rs
+++ b/tests/contest/contest/src/tests/fd_control/mod.rs
@@ -102,6 +102,7 @@ pub fn get_fd_control_test() -> TestGroup {
     );
     let test_closes_fd = Test::new("closes_fd", Box::new(closes_fd_test));
     let test_pass_single_fd = Test::new("pass_single_fd", Box::new(pass_single_fd_test));
+    // adding separately as one is conditional test and others are normal
     test_group.add(vec![Box::new(test_only_stdio)]);
     test_group.add(vec![
         Box::new(test_closes_fd),

--- a/tests/contest/contest/src/tests/lifecycle/container_create.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_create.rs
@@ -82,6 +82,10 @@ impl TestableGroup for ContainerCreate {
         "create"
     }
 
+    fn parallel(&self) -> bool {
+        true
+    }
+
     fn run_all(&self) -> Vec<(&'static str, TestResult)> {
         vec![
             ("empty_id", self.create_empty_id()),

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -93,6 +93,10 @@ impl TestableGroup for ContainerLifecycle {
         "lifecycle"
     }
 
+    fn parallel(&self) -> bool {
+        true
+    }
+
     fn run_all(&self) -> Vec<(&'static str, TestResult)> {
         vec![
             ("create", self.create()),

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -2,6 +2,7 @@ pub mod cgroups;
 pub mod devices;
 pub mod domainname;
 pub mod example;
+pub mod fd_control;
 pub mod hooks;
 pub mod hostname;
 pub mod intel_rdt;

--- a/tests/contest/contest/src/tests/pidfile/pidfile_test.rs
+++ b/tests/contest/contest/src/tests/pidfile/pidfile_test.rs
@@ -16,9 +16,6 @@ fn cleanup(id: &Uuid, bundle: &tempfile::TempDir) {
     delete_container(&str_id, bundle).unwrap().wait().unwrap();
 }
 
-// here we have to manually create and manage the container
-// as the test_inside_container does not provide a way to set the pid file argument
-// TODO: this comment is now out of date, the test just needs updating
 fn test_pidfile() -> TestResult {
     // create id for the container and pidfile
     let container_id = generate_uuid();

--- a/tests/contest/contest/src/tests/pidfile/pidfile_test.rs
+++ b/tests/contest/contest/src/tests/pidfile/pidfile_test.rs
@@ -1,13 +1,12 @@
 use std::fs::File;
-use std::process::{Command, Stdio};
 
 use anyhow::anyhow;
 use test_framework::{Test, TestGroup, TestResult};
 use uuid::Uuid;
 
 use crate::utils::{
-    delete_container, generate_uuid, get_runtime_path, get_state, kill_container, prepare_bundle,
-    State,
+    create_container, delete_container, generate_uuid, get_state, kill_container, prepare_bundle,
+    CreateOptions, State,
 };
 
 #[inline]
@@ -18,7 +17,8 @@ fn cleanup(id: &Uuid, bundle: &tempfile::TempDir) {
 }
 
 // here we have to manually create and manage the container
-// as the test_inside container does not provide a way to set the pid file argument
+// as the test_inside_container does not provide a way to set the pid file argument
+// TODO: this comment is now out of date, the test just needs updating
 fn test_pidfile() -> TestResult {
     // create id for the container and pidfile
     let container_id = generate_uuid();
@@ -30,22 +30,14 @@ fn test_pidfile() -> TestResult {
     let _ = File::create(&pidfile_path).unwrap();
 
     // start the container
-    Command::new(get_runtime_path())
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .arg("--root")
-        .arg(bundle.as_ref().join("runtime"))
-        .arg("create")
-        .arg(container_id.to_string())
-        .arg("--bundle")
-        .arg(bundle.as_ref().join("bundle"))
-        .arg("--pid-file")
-        .arg(pidfile_path)
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap();
+    create_container(
+        &container_id.to_string(),
+        &bundle,
+        &CreateOptions::default().with_extra_args(&["--pid-file".as_ref(), pidfile_path.as_ref()]),
+    )
+    .unwrap()
+    .wait()
+    .unwrap();
 
     let (out, err) = get_state(&container_id.to_string(), &bundle).unwrap();
 

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -7,5 +7,5 @@ pub use support::{
 };
 pub use test_utils::{
     create_container, delete_container, get_state, kill_container, test_inside_container,
-    test_outside_container, State,
+    test_outside_container, CreateOptions, State,
 };

--- a/tests/contest/runtimetest/src/main.rs
+++ b/tests/contest/runtimetest/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
         "process_rlimits" => tests::validate_process_rlimits(&spec),
         "no_pivot" => tests::validate_rootfs(),
         "process_oom_score_adj" => tests::validate_process_oom_score_adj(&spec),
+        "fd_control" => tests::validate_fd_control(&spec),
         _ => eprintln!("error due to unexpected execute test name: {execute_test}"),
     }
 }

--- a/tests/contest/test_framework/src/testable.rs
+++ b/tests/contest/test_framework/src/testable.rs
@@ -39,6 +39,7 @@ pub trait Testable {
 /// Test groups are used to group tests in sensible manner as well as provide namespacing to tests
 pub trait TestableGroup {
     fn get_name(&self) -> &'static str;
+    fn parallel(&self) -> bool;
     fn run_all(&self) -> Vec<(&'static str, TestResult)>;
     fn run_selected(&self, selected: &[&str]) -> Vec<(&'static str, TestResult)>;
 }


### PR DESCRIPTION
https://github.com/containers/youki/pull/2663 seems to have broken preserve-fds by unconditionally closing everything aside from stdio in the container main process.

I've fixed this by effectively reverting part of that PR. Typically I'd expect it to be a bad idea to revert security fixes, but unfortunately I don't really understand much of the diagnosis at https://github.com/containers/youki/pull/2663 and can't get it to stack up against my observations of previous and current behavior of youki.

Specifically:

> youki does leak a directory file descriptor from the host mount namespace, but it just so happens that the directory is the rootfs of the container

I checked out 04f8f2d79d4355af30294b5c581fe040ed96aa42 (the commit before the fix PR was merged) and couldn't reproduce this. With a default config generated by `youki spec` and a command of `"ls", "-al", "/proc/self/fd"` I get the following output:

```
dr-x------    2 root     root             0 Aug 24 20:17 .
dr-xr-xr-x    9 root     root             0 Aug 24 20:17 ..
lrwx------    1 root     root            64 Aug 24 20:17 0 -> /dev/pts/9
lrwx------    1 root     root            64 Aug 24 20:17 1 -> /dev/pts/9
lrwx------    1 root     root            64 Aug 24 20:17 2 -> /dev/pts/9
ls: /proc/self/fd/3: cannot read link: No such file or directory
lr-x------    1 root     root            64 Aug 24 20:17 3
```

This is what I'd expect - preserve fds (https://github.com/containers/youki/pull/177) already closes all the FDs in the init process before execution. FD 3 here is `ls` opening the directory.

I *can* reproduce a leak by passing `--preserve-fds 10` (I get something at FD 7, which seems to be the rootfs being referenced) - but the fix solves this by just making the preserve-fds flag useless. I fix this by actually closing the culprit directory, and then additionally verifying by hand that passing `--preserve-fds 100` does not list any other stray FDs that are being passed down.

> In addition, no care is taken to make sure all non-stdio files are O_CLOEXEC

Again I don't understand this - the preserve-fds PR does exactly that by marking everything as O_CLOEXEC before process execution? It is not ideal that passing `--preserve-fds` leaks something, but I've fixed that in this PR in a more precise way.

> In addition, any file descriptors passed to youki are not closed until the container process is executed, meaning that easily-overlooked programming errors by users of youki can lead to these attacks becoming exploitable.

I also don't understand this - the preserve fds PR sets the O_CLOEXEC flag in the init process, before execing the user process. It seems better to do this as late as possible, so fewer file descriptors can slip in? The vulnerability fix puts it in the main process, giving ample opportunity for other FDs to be opened and leaked.

Perhaps there's more detail that would help my confusion in the review in the private repository that would help? Per:

> This PR has already been approved by jprendes rumpl yihuaf in private repository.

Edit: oops, sorry for the mentions, those were unintentional