### PR TITLE
Integration test: cgroup v1 relative-cpus tests

### DIFF
--- a/tests/contest/contest/src/tests/cgroups/cpu/mod.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/mod.rs
@@ -41,11 +41,16 @@ fn create_cpu_spec(
     builder.build().context("failed to build cpu spec")
 }
 
-fn create_spec(cgroup_name: &str, case: LinuxCpu) -> Result<Spec> {
+fn create_spec(cgroup_name: &str, case: LinuxCpu, is_relative: bool) -> Result<Spec> {
+    let cgroups_path = if is_relative {
+        Path::new("testdir/runtime-test").join(cgroup_name)
+    } else {
+        Path::new("/runtime-test").join(cgroup_name)
+    };
     let spec = SpecBuilder::default()
         .linux(
             LinuxBuilder::default()
-                .cgroups_path(Path::new("/runtime-test").join(cgroup_name))
+                .cgroups_path(cgroups_path)
                 .resources(
                     LinuxResourcesBuilder::default()
                         .cpu(case)

--- a/tests/contest/contest/src/tests/cgroups/cpu/mod.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/mod.rs
@@ -41,16 +41,11 @@ fn create_cpu_spec(
     builder.build().context("failed to build cpu spec")
 }
 
-fn create_spec(cgroup_name: &str, case: LinuxCpu, is_relative: bool) -> Result<Spec> {
-    let cgroups_path = if is_relative {
-        Path::new("testdir/runtime-test").join(cgroup_name)
-    } else {
-        Path::new("/runtime-test").join(cgroup_name)
-    };
+fn create_spec_with_cgroup_path(cgroup_path: &str, case: LinuxCpu) -> Result<Spec> {
     let spec = SpecBuilder::default()
         .linux(
             LinuxBuilder::default()
-                .cgroups_path(cgroups_path)
+                .cgroups_path(Path::new(cgroup_path))
                 .resources(
                     LinuxResourcesBuilder::default()
                         .cpu(case)
@@ -64,6 +59,10 @@ fn create_spec(cgroup_name: &str, case: LinuxCpu, is_relative: bool) -> Result<S
         .context("failed to build spec")?;
 
     Ok(spec)
+}
+
+fn create_spec(cgroup_name: &str, case: LinuxCpu) -> Result<Spec> {
+    create_spec_with_cgroup_path(&format!("/runtime-test/{}", cgroup_name), case)
 }
 
 fn create_empty_spec(cgroup_name: &str) -> Result<Spec> {

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -238,12 +238,13 @@ fn check_cgroup_subsystem(
     debug!("reading value from {:?}", cgroup_path);
     let content = fs::read_to_string(&cgroup_path)
         .with_context(|| format!("failed to read {cgroup_path:?}"))?;
+    let trimmed = content.trim();
     if let Some(v) = expected.downcast_ref::<u64>() {
-        assert_eq!(&content.parse::<u64>()?, v);
+        assert_eq!(&trimmed.parse::<u64>()?, v);
     } else if let Some(v) = expected.downcast_ref::<i64>() {
-        assert_eq!(&content.parse::<i64>()?, v);
+        assert_eq!(&trimmed.parse::<i64>()?, v);
     } else if let Some(v) = expected.downcast_ref::<String>() {
-        assert_eq!(&content, v);
+        assert_eq!(&trimmed, v);
     }
     Ok(())
 }

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -2,11 +2,10 @@ use std::fs;
 use std::path::Path;
 use std::string::ToString;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use libcgroups::common;
 use num_cpus;
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
-use tracing::debug;
 
 use super::{create_cpu_spec, create_empty_spec, create_spec};
 use crate::utils::test_outside_container;
@@ -235,9 +234,7 @@ fn check_cgroup_subsystem(
         .join(cgroup_name)
         .join(filename);
 
-    debug!("reading value from {:?}", cgroup_path);
-    let content = fs::read_to_string(&cgroup_path)
-        .with_context(|| format!("failed to read {cgroup_path:?}"))?;
+    let content = fs::read_to_string(&cgroup_path)?;
     let trimmed = content.trim();
     assert_eq!(trimmed, expected.to_string());
     Ok(())
@@ -262,37 +259,31 @@ fn test_relative_cpus() -> TestResult {
             "test_relative_cpus",
             "cpu,cpuacct",
             "cpu.shares",
-            &test_result!(case.shares().context("no shares value in cpu spec")),
+            &case.shares().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
             "test_relative_cpus",
             "cpu,cpuacct",
             "cpu.cfs_period_us",
-            &test_result!(case.period().context("no period value in cpu spec")),
+            &case.period().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
             "test_relative_cpus",
             "cpu,cpuacct",
             "cpu.cfs_quota_us",
-            &test_result!(case.quota().context("no period value in cpu spec")),
+            &case.quota().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
             "test_relative_cpus",
             "cpuset",
             "cpuset.cpus",
-            &test_result!(case
-                .cpus()
-                .to_owned()
-                .context("no period value in cpu spec"))
+            &case.cpus().to_owned().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
             "test_relative_cpus",
             "cpuset",
             "cpuset.mems",
-            &test_result!(case
-                .mems()
-                .to_owned()
-                .context("no period value in cpu spec")),
+            &case.mems().to_owned().unwrap()
         ));
         TestResult::Passed
     })

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -1,10 +1,10 @@
 use std::fs;
 use std::path::Path;
+use std::string::ToString;
 
 use anyhow::{Context, Result};
 use libcgroups::common;
 use num_cpus;
-use std::string::ToString;
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 use tracing::debug;
 

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -1,10 +1,10 @@
-use std::any::Any;
 use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use libcgroups::common;
 use num_cpus;
+use std::string::ToString;
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 use tracing::debug;
 
@@ -227,7 +227,7 @@ fn check_cgroup_subsystem(
     cgroup_name: &str,
     subsystem: &str,
     filename: &str,
-    expected: &dyn Any,
+    expected: &dyn ToString,
 ) -> Result<()> {
     let cgroup_path = Path::new(CGROUP_ROOT)
         .join(subsystem)
@@ -239,13 +239,7 @@ fn check_cgroup_subsystem(
     let content = fs::read_to_string(&cgroup_path)
         .with_context(|| format!("failed to read {cgroup_path:?}"))?;
     let trimmed = content.trim();
-    if let Some(v) = expected.downcast_ref::<u64>() {
-        assert_eq!(&trimmed.parse::<u64>()?, v);
-    } else if let Some(v) = expected.downcast_ref::<i64>() {
-        assert_eq!(&trimmed.parse::<i64>()?, v);
-    } else if let Some(v) = expected.downcast_ref::<String>() {
-        assert_eq!(&trimmed, v);
-    }
+    assert_eq!(trimmed, expected.to_string());
     Ok(())
 }
 

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -2,14 +2,15 @@ use std::fs;
 use std::path::Path;
 use std::string::ToString;
 
-use super::{create_cpu_spec, create_empty_spec, create_spec};
-use crate::utils::test_outside_container;
-use crate::utils::test_utils::check_container_created;
 use anyhow::Result;
 use libcgroups::common;
 use libcgroups::v1::{util, ControllerType};
 use num_cpus;
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
+
+use super::{create_cpu_spec, create_empty_spec, create_spec};
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::check_container_created;
 
 const CPU_CGROUP_PREFIX: &str = "/sys/fs/cgroup/cpu,cpuacct";
 const DEFAULT_REALTIME_PERIOD: u64 = 1000000;

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -255,32 +255,33 @@ fn test_relative_cpus() -> TestResult {
 
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
+        let cgroup_name = "test_relative_cpus";
         test_result!(check_cgroup_subsystem(
-            "test_relative_cpus",
+            cgroup_name,
             "cpu,cpuacct",
             "cpu.shares",
             &case.shares().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
-            "test_relative_cpus",
+            cgroup_name,
             "cpu,cpuacct",
             "cpu.cfs_period_us",
             &case.period().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
-            "test_relative_cpus",
+            cgroup_name,
             "cpu,cpuacct",
             "cpu.cfs_quota_us",
             &case.quota().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
-            "test_relative_cpus",
+            cgroup_name,
             "cpuset",
             "cpuset.cpus",
             &case.cpus().to_owned().unwrap(),
         ));
         test_result!(check_cgroup_subsystem(
-            "test_relative_cpus",
+            cgroup_name,
             "cpuset",
             "cpuset.mems",
             &case.mems().to_owned().unwrap()

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -208,7 +208,7 @@ fn test_cpu_cgroups() -> TestResult {
     ];
 
     for case in cases.into_iter() {
-        let spec = test_result!(create_spec(cgroup_name, case));
+        let spec = test_result!(create_spec(cgroup_name, case, false));
         let test_result = test_outside_container(spec, &|data| {
             test_result!(check_container_created(&data));
 
@@ -231,7 +231,7 @@ fn check_cgroup_subsystem(
 ) -> Result<()> {
     let mount_point = util::get_subsystem_mount_point(subsystem)?;
     let cgroup_path = mount_point
-        .join("runtime-test")
+        .join("testdir/runtime-test")
         .join(cgroup_name)
         .join(filename);
 
@@ -252,7 +252,7 @@ fn test_relative_cpus() -> TestResult {
         get_realtime_period(),
         get_realtime_runtime(),
     ));
-    let spec = test_result!(create_spec("test_relative_cpus", case.clone()));
+    let spec = test_result!(create_spec("test_relative_cpus", case.clone(), true));
 
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
@@ -320,7 +320,7 @@ fn test_cpu_idle_set() -> TestResult {
         realtime_runtime,
     ));
 
-    let spec = test_result!(create_spec(cgroup_name, cpu));
+    let spec = test_result!(create_spec(cgroup_name, cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         TestResult::Passed
@@ -344,7 +344,7 @@ fn test_cpu_idle_default() -> TestResult {
         realtime_period,
         realtime_runtime,
     ));
-    let spec = test_result!(create_spec(cgroup_name, cpu));
+    let spec = test_result!(create_spec(cgroup_name, cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         TestResult::Passed

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -8,7 +8,7 @@ use libcgroups::v1::{util, ControllerType};
 use num_cpus;
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
-use super::{create_cpu_spec, create_empty_spec, create_spec};
+use super::{create_cpu_spec, create_empty_spec, create_spec, create_spec_with_cgroup_path};
 use crate::utils::test_outside_container;
 use crate::utils::test_utils::check_container_created;
 
@@ -208,7 +208,7 @@ fn test_cpu_cgroups() -> TestResult {
     ];
 
     for case in cases.into_iter() {
-        let spec = test_result!(create_spec(cgroup_name, case, false));
+        let spec = test_result!(create_spec(cgroup_name, case));
         let test_result = test_outside_container(spec, &|data| {
             test_result!(check_container_created(&data));
 
@@ -252,7 +252,10 @@ fn test_relative_cpus() -> TestResult {
         get_realtime_period(),
         get_realtime_runtime(),
     ));
-    let spec = test_result!(create_spec("test_relative_cpus", case.clone(), true));
+    let spec = test_result!(create_spec_with_cgroup_path(
+        "testdir/runtime-test/test_relative_cpus",
+        case.clone()
+    ));
 
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
@@ -320,7 +323,7 @@ fn test_cpu_idle_set() -> TestResult {
         realtime_runtime,
     ));
 
-    let spec = test_result!(create_spec(cgroup_name, cpu, false));
+    let spec = test_result!(create_spec(cgroup_name, cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         TestResult::Passed
@@ -344,7 +347,7 @@ fn test_cpu_idle_default() -> TestResult {
         realtime_period,
         realtime_runtime,
     ));
-    let spec = test_result!(create_spec(cgroup_name, cpu, false));
+    let spec = test_result!(create_spec(cgroup_name, cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         TestResult::Passed

--- a/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
@@ -34,7 +34,7 @@ fn test_cpu_idle_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_idle_set", cpu, false));
+    let spec = test_result!(create_spec("test_cpu_idle_set", cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_set", idle));
@@ -47,7 +47,7 @@ fn test_cpu_idle_default() -> TestResult {
     let default_idle = 0;
     let cpu = test_result!(LinuxCpuBuilder::default().build().context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_idle_default", cpu, false));
+    let spec = test_result!(create_spec("test_cpu_idle_default", cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_default", default_idle));
@@ -64,7 +64,7 @@ fn test_cpu_weight_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_weight_valid_set", cpu, false));
+    let spec = test_result!(create_spec("test_cpu_weight_valid_set", cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
@@ -84,7 +84,7 @@ fn test_cpu_weight_zero_ignored() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_weight_zero_ignored", cpu, false));
+    let spec = test_result!(create_spec("test_cpu_weight_zero_ignored", cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
@@ -104,11 +104,7 @@ fn test_cpu_weight_too_high_maximum_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec(
-        "test_cpu_weight_too_high_maximum_set",
-        cpu,
-        false
-    ));
+    let spec = test_result!(create_spec("test_cpu_weight_too_high_maximum_set", cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
@@ -127,7 +123,7 @@ fn test_cpu_quota_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_quota_valid_set", cpu, false));
+    let spec = test_result!(create_spec("test_cpu_quota_valid_set", cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
@@ -147,7 +143,7 @@ fn test_cpu_quota_zero_default_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_quota_zero_default_set", cpu, false));
+    let spec = test_result!(create_spec("test_cpu_quota_zero_default_set", cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
@@ -169,8 +165,7 @@ fn test_cpu_quota_negative_default_set() -> TestResult {
 
     let spec = test_result!(create_spec(
         "test_cpu_quota_negative_value_default_set",
-        cpu,
-        false
+        cpu
     ));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
@@ -193,7 +188,7 @@ fn test_cpu_period_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_period_valid_set", cpu, false));
+    let spec = test_result!(create_spec("test_cpu_period_valid_set", cpu));
     test_result!(prepare_cpu_max(
         &spec,
         &quota.to_string(),
@@ -218,11 +213,7 @@ fn test_cpu_quota_period_unspecified_unchanged() -> TestResult {
     let expected_period = 250_000;
     let cpu = test_result!(LinuxCpuBuilder::default().build().context("build cpu spec"));
 
-    let spec = test_result!(create_spec(
-        "test_cpu_period_unspecified_unchanged",
-        cpu,
-        false
-    ));
+    let spec = test_result!(create_spec("test_cpu_period_unspecified_unchanged", cpu,));
     test_result!(prepare_cpu_max(
         &spec,
         &quota.to_string(),
@@ -249,11 +240,7 @@ fn test_cpu_period_and_quota_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec(
-        "test_cpu_period_and_quota_valid_set",
-        cpu,
-        false
-    ));
+    let spec = test_result!(create_spec("test_cpu_period_and_quota_valid_set", cpu));
 
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));

--- a/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
@@ -34,7 +34,7 @@ fn test_cpu_idle_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_idle_set", cpu));
+    let spec = test_result!(create_spec("test_cpu_idle_set", cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_set", idle));
@@ -47,7 +47,7 @@ fn test_cpu_idle_default() -> TestResult {
     let default_idle = 0;
     let cpu = test_result!(LinuxCpuBuilder::default().build().context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_idle_default", cpu));
+    let spec = test_result!(create_spec("test_cpu_idle_default", cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_default", default_idle));
@@ -64,7 +64,7 @@ fn test_cpu_weight_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_weight_valid_set", cpu));
+    let spec = test_result!(create_spec("test_cpu_weight_valid_set", cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
@@ -84,7 +84,7 @@ fn test_cpu_weight_zero_ignored() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_weight_zero_ignored", cpu));
+    let spec = test_result!(create_spec("test_cpu_weight_zero_ignored", cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
@@ -104,7 +104,11 @@ fn test_cpu_weight_too_high_maximum_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_weight_too_high_maximum_set", cpu));
+    let spec = test_result!(create_spec(
+        "test_cpu_weight_too_high_maximum_set",
+        cpu,
+        false
+    ));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
@@ -123,7 +127,7 @@ fn test_cpu_quota_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_quota_valid_set", cpu));
+    let spec = test_result!(create_spec("test_cpu_quota_valid_set", cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
@@ -143,7 +147,7 @@ fn test_cpu_quota_zero_default_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_quota_zero_default_set", cpu));
+    let spec = test_result!(create_spec("test_cpu_quota_zero_default_set", cpu, false));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
@@ -165,7 +169,8 @@ fn test_cpu_quota_negative_default_set() -> TestResult {
 
     let spec = test_result!(create_spec(
         "test_cpu_quota_negative_value_default_set",
-        cpu
+        cpu,
+        false
     ));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
@@ -188,7 +193,7 @@ fn test_cpu_period_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_period_valid_set", cpu));
+    let spec = test_result!(create_spec("test_cpu_period_valid_set", cpu, false));
     test_result!(prepare_cpu_max(
         &spec,
         &quota.to_string(),
@@ -213,7 +218,11 @@ fn test_cpu_quota_period_unspecified_unchanged() -> TestResult {
     let expected_period = 250_000;
     let cpu = test_result!(LinuxCpuBuilder::default().build().context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_period_unspecified_unchanged", cpu));
+    let spec = test_result!(create_spec(
+        "test_cpu_period_unspecified_unchanged",
+        cpu,
+        false
+    ));
     test_result!(prepare_cpu_max(
         &spec,
         &quota.to_string(),
@@ -240,7 +249,11 @@ fn test_cpu_period_and_quota_valid_set() -> TestResult {
         .build()
         .context("build cpu spec"));
 
-    let spec = test_result!(create_spec("test_cpu_period_and_quota_valid_set", cpu));
+    let spec = test_result!(create_spec(
+        "test_cpu_period_and_quota_valid_set",
+        cpu,
+        false
+    ));
 
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));


### PR DESCRIPTION
Hi, I have implemented the test_relative_cpus function to contribute to #361  by referencing [`linux_cgroups_relative_cpus.go`](https://github.com/opencontainers/runtime-tools/blob/master/validation/linux_cgroups_relative_cpus/linux_cgroups_relative_cpus.go) and [`cpu/v2.rs`](https://github.com/containers/youki/blob/main/tests/contest/contest/src/tests/cgroups/cpu/v2.rs). However, I encountered a few issues:

The current implementation closely mirrors the logic in v2.rs. Since there isn't a clear distinction between v1 and v2 logic in linux_cgroups_relative_cpus.go, would it be better to extract the common logic into a shared module?

I am also unsure about the correct way to run the tests. The just test-contest command on the main branch fails on Ubuntu 20.04. Could you provide guidance on resolving this issue?

Thank you for your help. I have learned a lot from this process.