### PR TITLE
Use MountOption enum to parse mount options defined in the spec

### DIFF
--- a/crates/libcontainer/src/rootfs/utils.rs
+++ b/crates/libcontainer/src/rootfs/utils.rs
@@ -175,9 +175,9 @@ pub fn parse_mount(m: &Mount) -> std::result::Result<MountOptionConfig, MountErr
                 }
             } {
                 if is_clear {
-                    flags.remove(flag);
+                    flags &= !flag;
                 } else {
-                    flags.insert(flag);
+                    flags |= flag;
                 }
                 continue;
             }

--- a/crates/libcontainer/src/rootfs/utils.rs
+++ b/crates/libcontainer/src/rootfs/utils.rs
@@ -245,7 +245,7 @@ mod tests {
         )?;
         assert_eq!(
             MountOptionConfig {
-                flags: MsFlags::MS_NOSUID,
+                flags: MsFlags::MS_NOSUID | MsFlags::MS_STRICTATIME,
                 data: "mode=755,size=65536k".to_string(),
                 rec_attr: None,
             },
@@ -366,7 +366,8 @@ mod tests {
                 flags: MsFlags::MS_NOSUID
                     | MsFlags::MS_NOEXEC
                     | MsFlags::MS_NODEV
-                    | MsFlags::MS_RDONLY,
+                    | MsFlags::MS_RDONLY
+                    | MsFlags::MS_RELATIME,
                 data: "".to_string(),
                 rec_attr: None
             },

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -38,6 +38,101 @@ const MOUNT_ATTR_STRICTATIME: u64 = 0x00000020;
 const MOUNT_ATTR_NODIRATIME: u64 = 0x00000080;
 const MOUNT_ATTR_NOSYMFOLLOW: u64 = 0x00200000;
 
+/// Constants used by mount(2).
+pub enum MountOption {
+    Defaults(bool, MsFlags),
+    Ro(bool, MsFlags),
+    Rw(bool, MsFlags),
+    Suid(bool, MsFlags),
+    Nosuid(bool, MsFlags),
+    Dev(bool, MsFlags),
+    Nodev(bool, MsFlags),
+    Exec(bool, MsFlags),
+    Noexec(bool, MsFlags),
+    Sync(bool, MsFlags),
+    Async(bool, MsFlags),
+    Dirsync(bool, MsFlags),
+    Remount(bool, MsFlags),
+    Mand(bool, MsFlags),
+    Nomand(bool, MsFlags),
+    Atime(bool, MsFlags),
+    Noatime(bool, MsFlags),
+    Diratime(bool, MsFlags),
+    Nodiratime(bool, MsFlags),
+    Bind(bool, MsFlags),
+    Rbind(bool, MsFlags),
+    Unbindable(bool, MsFlags),
+    Runbindable(bool, MsFlags),
+    Private(bool, MsFlags),
+    Rprivate(bool, MsFlags),
+    Shared(bool, MsFlags),
+    Rshared(bool, MsFlags),
+    Slave(bool, MsFlags),
+    Rslave(bool, MsFlags),
+    Relatime(bool, MsFlags),
+    Norelatime(bool, MsFlags),
+    Strictatime(bool, MsFlags),
+    Nostrictatime(bool, MsFlags),
+}
+
+impl FromStr for MountOption {
+    type Err = String;
+
+    fn from_str(option: &str) -> std::result::Result<Self, Self::Err> {
+        match option {
+            "defaults" => Ok(MountOption::Defaults(false, MsFlags::empty())),
+            "ro" => Ok(MountOption::Ro(false, MsFlags::MS_RDONLY)),
+            "rw" => Ok(MountOption::Rw(true, MsFlags::MS_RDONLY)),
+            "suid" => Ok(MountOption::Suid(true, MsFlags::MS_NOSUID)),
+            "nosuid" => Ok(MountOption::Nosuid(false, MsFlags::MS_NOSUID)),
+            "dev" => Ok(MountOption::Dev(true, MsFlags::MS_NODEV)),
+            "nodev" => Ok(MountOption::Nodev(false, MsFlags::MS_NODEV)),
+            "exec" => Ok(MountOption::Exec(true, MsFlags::MS_NOEXEC)),
+            "noexec" => Ok(MountOption::Noexec(false, MsFlags::MS_NOEXEC)),
+            "sync" => Ok(MountOption::Sync(false, MsFlags::MS_SYNCHRONOUS)),
+            "async" => Ok(MountOption::Async(true, MsFlags::MS_SYNCHRONOUS)),
+            "dirsync" => Ok(MountOption::Dirsync(false, MsFlags::MS_DIRSYNC)),
+            "remount" => Ok(MountOption::Remount(false, MsFlags::MS_REMOUNT)),
+            "mand" => Ok(MountOption::Mand(false, MsFlags::MS_MANDLOCK)),
+            "nomand" => Ok(MountOption::Nomand(true, MsFlags::MS_MANDLOCK)),
+            "atime" => Ok(MountOption::Atime(true, MsFlags::MS_NOATIME)),
+            "noatime" => Ok(MountOption::Noatime(false, MsFlags::MS_NOATIME)),
+            "diratime" => Ok(MountOption::Diratime(true, MsFlags::MS_NODIRATIME)),
+            "nodiratime" => Ok(MountOption::Nodiratime(false, MsFlags::MS_NODIRATIME)),
+            "bind" => Ok(MountOption::Bind(false, MsFlags::MS_BIND)),
+            "rbind" => Ok(MountOption::Rbind(
+                false,
+                MsFlags::MS_BIND | MsFlags::MS_REC,
+            )),
+            "unbindable" => Ok(MountOption::Unbindable(false, MsFlags::MS_UNBINDABLE)),
+            "runbindable" => Ok(MountOption::Runbindable(
+                false,
+                MsFlags::MS_UNBINDABLE | MsFlags::MS_REC,
+            )),
+            "private" => Ok(MountOption::Private(true, MsFlags::MS_PRIVATE)),
+            "rprivate" => Ok(MountOption::Rprivate(
+                true,
+                MsFlags::MS_PRIVATE | MsFlags::MS_REC,
+            )),
+            "shared" => Ok(MountOption::Shared(true, MsFlags::MS_SHARED)),
+            "rshared" => Ok(MountOption::Rshared(
+                true,
+                MsFlags::MS_SHARED | MsFlags::MS_REC,
+            )),
+            "slave" => Ok(MountOption::Slave(true, MsFlags::MS_SLAVE)),
+            "rslave" => Ok(MountOption::Rslave(
+                true,
+                MsFlags::MS_SLAVE | MsFlags::MS_REC,
+            )),
+            "relatime" => Ok(MountOption::Relatime(false, MsFlags::MS_RELATIME)),
+            "norelatime" => Ok(MountOption::Norelatime(true, MsFlags::MS_RELATIME)),
+            "strictatime" => Ok(MountOption::Strictatime(false, MsFlags::MS_STRICTATIME)),
+            "nostrictatime" => Ok(MountOption::Nostrictatime(true, MsFlags::MS_STRICTATIME)),
+            _ => Err(option.to_string()),
+        }
+    }
+}
+
 /// Constants used by mount_setattr(2).
 pub enum MountRecursive {
     /// Mount read-only.

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -75,6 +75,50 @@ pub enum MountOption {
     Nostrictatime(bool, MsFlags),
 }
 
+impl MountOption {
+    // Return all possible mount options
+    pub fn known_options() -> Vec<String> {
+        [
+            "defaults",
+            "ro",
+            "rw",
+            "suid",
+            "nosuid",
+            "dev",
+            "nodev",
+            "exec",
+            "noexec",
+            "sync",
+            "async",
+            "dirsync",
+            "remount",
+            "mand",
+            "nomand",
+            "atime",
+            "noatime",
+            "diratime",
+            "nodiratime",
+            "bind",
+            "rbind",
+            "unbindable",
+            "runbindable",
+            "private",
+            "rprivate",
+            "shared",
+            "rshared",
+            "slave",
+            "rslave",
+            "relatime",
+            "norelatime",
+            "strictatime",
+            "nostrictatime",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+}
+
 impl FromStr for MountOption {
     type Err = String;
 
@@ -694,12 +738,13 @@ mod tests {
 
     use std::fs;
     use std::os::unix::prelude::AsRawFd;
+    use std::str::FromStr;
 
     use anyhow::{bail, Context, Result};
     use nix::{fcntl, sys, unistd};
     use serial_test::serial;
 
-    use super::LinuxSyscall;
+    use super::{LinuxSyscall, MountOption};
     use crate::syscall::Syscall;
 
     #[test]
@@ -759,6 +804,17 @@ mod tests {
         }
 
         unistd::close(fd)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_known_mount_options_implemented() -> Result<()> {
+        for option in MountOption::known_options() {
+            match MountOption::from_str(&option) {
+                Ok(_) => {}
+                Err(e) => bail!("failed to parse mount option: {}", e),
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes MountOption so that it can be used to parse mount options defined in the OCI spec. 

The method `MountOption::known_options` is intended to be used in https://github.com/youki-dev/youki/pull/2837 to report possible mount options as part of the feature subcommand's output.