### PR TITLE
libcontainer: support set stdios for container

### DIFF
--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -103,6 +103,9 @@ impl InitContainerBuilder {
             detached: self.detached,
             executor: self.base.executor,
             no_pivot: self.no_pivot,
+            stdin: self.base.stdin,
+            stdout: self.base.stdout,
+            stderr: self.base.stderr,
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -143,6 +143,9 @@ impl TenantContainerBuilder {
             detached: self.detached,
             executor: self.base.executor,
             no_pivot: false,
+            stdin: self.base.stdin,
+            stdout: self.base.stdout,
+            stderr: self.base.stderr,
         };
 
         let pid = builder_impl.create()?;

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -44,4 +44,10 @@ pub struct ContainerArgs {
     pub executor: Box<dyn Executor>,
     /// If do not use pivot root to jail process inside rootfs
     pub no_pivot: bool,
+    // RawFd set to stdin of the container init process.
+    pub stdin: Option<RawFd>,
+    // RawFd set to stdout of the container init process.
+    pub stdout: Option<RawFd>,
+    // RawFd set to stderr of the container init process.
+    pub stderr: Option<RawFd>,
 }


### PR DESCRIPTION
currently the container can only inherit stdios from it's parent process, the one who create container with libcontainer can not set stdios to a different file. this restrict the use of the libcontainer that a process can only create one container by itself, because we can't imagine that every container this process creates share the same stdin/stdout/stderr.


