### PR TITLE
Add option to spawn processes as siblings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,6 +2008,7 @@ dependencies = [
  "regex",
  "rust-criu",
  "safe-path",
+ "scopeguard",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -59,3 +59,4 @@ serial_test = "3.1.1"
 tempfile = "3"
 anyhow = "1.0"
 rand = { version = "0.8.5" }
+scopeguard = "1"

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -57,6 +57,8 @@ pub(super) struct ContainerBuilderImpl {
     pub stdout: Option<OwnedFd>,
     // RawFd set to stderr of the container init process.
     pub stderr: Option<OwnedFd>,
+    // Indicate if the init process should be a sibling of the main process.
+    pub as_sibling: bool,
 }
 
 impl ContainerBuilderImpl {
@@ -172,6 +174,7 @@ impl ContainerBuilderImpl {
             stdin: self.stdin.as_ref().map(|x| x.as_raw_fd()),
             stdout: self.stdout.as_ref().map(|x| x.as_raw_fd()),
             stderr: self.stderr.as_ref().map(|x| x.as_raw_fd()),
+            as_sibling: self.as_sibling,
         };
 
         let (init_pid, need_to_clean_up_intel_rdt_dir) =

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -21,6 +21,7 @@ pub struct InitContainerBuilder {
     use_systemd: bool,
     detached: bool,
     no_pivot: bool,
+    as_sibling: bool,
 }
 
 impl InitContainerBuilder {
@@ -33,12 +34,20 @@ impl InitContainerBuilder {
             use_systemd: true,
             detached: true,
             no_pivot: false,
+            as_sibling: false,
         }
     }
 
     /// Sets if systemd should be used for managing cgroups
     pub fn with_systemd(mut self, should_use: bool) -> Self {
         self.use_systemd = should_use;
+        self
+    }
+
+    /// Sets if the init process should be run as a child or a sibling of
+    /// the calling process
+    pub fn as_sibling(mut self, as_sibling: bool) -> Self {
+        self.as_sibling = as_sibling;
         self
     }
 
@@ -106,6 +115,7 @@ impl InitContainerBuilder {
             stdin: self.base.stdin,
             stdout: self.base.stdout,
             stderr: self.base.stderr,
+            as_sibling: self.as_sibling,
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -43,6 +43,7 @@ pub struct TenantContainerBuilder {
     capabilities: Vec<String>,
     process: Option<PathBuf>,
     detached: bool,
+    as_sibling: bool,
 }
 
 impl TenantContainerBuilder {
@@ -59,6 +60,7 @@ impl TenantContainerBuilder {
             capabilities: Vec::new(),
             process: None,
             detached: false,
+            as_sibling: false,
         }
     }
 
@@ -92,6 +94,13 @@ impl TenantContainerBuilder {
 
     pub fn with_process<P: Into<PathBuf>>(mut self, path: Option<P>) -> Self {
         self.process = path.map(|p| p.into());
+        self
+    }
+
+    /// Sets if the init process should be run as a child or a sibling of
+    /// the calling process
+    pub fn as_sibling(mut self, as_sibling: bool) -> Self {
+        self.as_sibling = as_sibling;
         self
     }
 
@@ -145,6 +154,7 @@ impl TenantContainerBuilder {
             stdin: self.base.stdin,
             stdout: self.base.stdout,
             stderr: self.base.stderr,
+            as_sibling: self.as_sibling,
         };
 
         let pid = builder_impl.create()?;

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -50,4 +50,6 @@ pub struct ContainerArgs {
     pub stdout: Option<RawFd>,
     // RawFd set to stderr of the container init process.
     pub stderr: Option<RawFd>,
+    // Indicate if the init process should be a sibling of the main process.
+    pub as_sibling: bool,
 }

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -84,7 +84,13 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
         ProcessError::SyscallOther(err)
     })?;
 
-    let intermediate_pid = fork::container_clone(cb).map_err(|err| {
+    let container_clone_fn = if container_args.as_sibling {
+        fork::container_clone_sibling
+    } else {
+        fork::container_clone
+    };
+
+    let intermediate_pid = container_clone_fn(cb).map_err(|err| {
         tracing::error!("failed to fork intermediate process: {}", err);
         ProcessError::IntermediateProcessFailed(err)
     })?;

--- a/crates/libcontainer/tests/as_sibling.rs
+++ b/crates/libcontainer/tests/as_sibling.rs
@@ -1,0 +1,115 @@
+use std::collections::HashMap;
+use std::fs::create_dir;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::Path;
+
+use anyhow::Result;
+use libcontainer::container::builder::ContainerBuilder;
+use libcontainer::syscall::syscall::SyscallType;
+use libcontainer::workload::{
+    Executor, ExecutorError, ExecutorSetEnvsError, ExecutorValidationError,
+};
+use nix::unistd::{getegid, geteuid};
+use oci_spec::runtime::{RootBuilder, Spec};
+use procfs::process::Process;
+use serial_test::serial;
+use tempfile::tempdir;
+
+fn prepare_container_root(root: impl AsRef<Path>) -> Result<()> {
+    let root = root.as_ref();
+    create_dir(root.join("rootfs"))?;
+
+    let uid = geteuid().as_raw();
+    let gid = getegid().as_raw();
+
+    let mut spec = Spec::rootless(uid, gid);
+    spec.set_root(
+        RootBuilder::default()
+            .path("rootfs")
+            .readonly(false)
+            .build()
+            .ok(),
+    );
+
+    spec.save(root.join("config.json"))?;
+
+    Ok(())
+}
+
+fn hash(v: impl Hash) -> u64 {
+    let mut hasher = DefaultHasher::default();
+    v.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[derive(Clone)]
+struct SomeExecutor;
+
+impl Executor for SomeExecutor {
+    fn setup_envs(&self, _: HashMap<String, String>) -> Result<(), ExecutorSetEnvsError> {
+        Ok(())
+    }
+
+    fn validate(&self, _: &Spec) -> Result<(), ExecutorValidationError> {
+        Ok(())
+    }
+
+    fn exec(&self, _: &Spec) -> Result<(), ExecutorError> {
+        Ok(())
+    }
+}
+
+#[test]
+#[serial]
+fn run_init_process_as_child() -> Result<()> {
+    let root = tempdir()?;
+    prepare_container_root(&root)?;
+
+    let id = format!("test-container-{:x}", hash(root.as_ref()));
+    let container = ContainerBuilder::new(id, SyscallType::Linux)
+        .with_executor(SomeExecutor)
+        .with_root_path(root.as_ref())?
+        .as_init(root.as_ref())
+        .build()?;
+
+    let container = scopeguard::guard(container, |mut container| {
+        let _ = container.delete(true);
+    });
+
+    let init_pid = container.pid().unwrap().as_raw();
+
+    let init_ppid = Process::new(init_pid)?.stat()?.ppid;
+    let this_pid = Process::myself()?.pid();
+
+    assert_eq!(init_ppid, this_pid);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn run_init_process_as_sibling() -> Result<()> {
+    let root = tempdir()?;
+    prepare_container_root(&root)?;
+
+    let id = format!("test-container-{:x}", hash(root.as_ref()));
+    let container = ContainerBuilder::new(id, SyscallType::Linux)
+        .with_executor(SomeExecutor)
+        .with_root_path(root.as_ref())?
+        .as_init(root.as_ref())
+        .as_sibling(true)
+        .build()?;
+
+    let container = scopeguard::guard(container, |mut container| {
+        let _ = container.delete(true);
+    });
+
+    let init_pid = container.pid().unwrap().as_raw();
+
+    let init_ppid = Process::new(init_pid)?.stat()?.ppid;
+    let this_ppid = Process::myself()?.stat()?.ppid;
+
+    assert_eq!(init_ppid, this_ppid);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the option to spawn processes as siblings of the calling processes instead of spawning them as children.
See #3011 for more context.