### PR TITLE
Fix : fix gid duplication, additional_gids etc not getting used in exec

### DIFF
--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -14,7 +14,7 @@ use nix::unistd::{pipe2, read, Pid};
 use oci_spec::runtime::{
     Capabilities as SpecCapabilities, Capability as SpecCapability, LinuxBuilder,
     LinuxCapabilities, LinuxCapabilitiesBuilder, LinuxNamespace, LinuxNamespaceBuilder,
-    LinuxNamespaceType, LinuxSchedulerPolicy, Process, ProcessBuilder, Spec,
+    LinuxNamespaceType, LinuxSchedulerPolicy, Process, ProcessBuilder, Spec, UserBuilder,
 };
 use procfs::process::Namespace;
 
@@ -32,6 +32,22 @@ const NAMESPACE_TYPES: &[&str] = &["ipc", "uts", "net", "pid", "mnt", "cgroup"];
 const TENANT_NOTIFY: &str = "tenant-notify-";
 const TENANT_TTY: &str = "tenant-tty-";
 
+fn get_path_from_spec(spec: &Spec) -> Option<String> {
+    let process = match spec.process() {
+        Some(p) => p,
+        None => return None,
+    };
+    let env = match process.env() {
+        Some(e) => e,
+        None => return None,
+    };
+    env.iter()
+        .find(|e| e.starts_with("PATH"))
+        .iter()
+        .next()
+        .map(|s| s.to_string())
+}
+
 /// Builder that can be used to configure the properties of a process
 /// that will join an existing container sandbox
 pub struct TenantContainerBuilder {
@@ -44,6 +60,9 @@ pub struct TenantContainerBuilder {
     process: Option<PathBuf>,
     detached: bool,
     as_sibling: bool,
+    additional_gids: Vec<u32>,
+    user: Option<u32>,
+    group: Option<u32>,
 }
 
 impl TenantContainerBuilder {
@@ -61,6 +80,9 @@ impl TenantContainerBuilder {
             process: None,
             detached: false,
             as_sibling: false,
+            additional_gids: vec![],
+            user: None,
+            group: None,
         }
     }
 
@@ -106,6 +128,21 @@ impl TenantContainerBuilder {
 
     pub fn with_detach(mut self, detached: bool) -> Self {
         self.detached = detached;
+        self
+    }
+
+    pub fn with_additional_gids(mut self, gids: Vec<u32>) -> Self {
+        self.additional_gids = gids;
+        self
+    }
+
+    pub fn with_user(mut self, user: Option<u32>) -> Self {
+        self.user = user;
+        self
+    }
+
+    pub fn with_group(mut self, group: Option<u32>) -> Self {
+        self.group = group;
         self
     }
 
@@ -323,9 +360,10 @@ impl TenantContainerBuilder {
         let process = if let Some(process) = &self.process {
             self.get_process(process)?
         } else {
+            let original_path_env = get_path_from_spec(spec);
             let mut process_builder = ProcessBuilder::default()
                 .args(self.get_args()?)
-                .env(self.get_environment());
+                .env(self.get_environment(original_path_env));
             if let Some(cwd) = self.get_working_dir()? {
                 process_builder = process_builder.cwd(cwd);
             }
@@ -337,6 +375,22 @@ impl TenantContainerBuilder {
             if let Some(caps) = self.get_capabilities(spec)? {
                 process_builder = process_builder.capabilities(caps);
             }
+
+            let mut user_builder = UserBuilder::default();
+
+            if !self.additional_gids.is_empty() {
+                user_builder = user_builder.additional_gids(self.additional_gids.clone());
+            }
+
+            if let Some(uid) = self.user {
+                user_builder = user_builder.uid(uid);
+            }
+
+            if let Some(gid) = self.group {
+                user_builder = user_builder.gid(gid);
+            }
+
+            process_builder = process_builder.user(user_builder.build()?);
 
             process_builder.build()?
         };
@@ -397,8 +451,28 @@ impl TenantContainerBuilder {
         Ok(self.args.clone())
     }
 
-    fn get_environment(&self) -> Vec<String> {
-        self.env.iter().map(|(k, v)| format!("{k}={v}")).collect()
+    fn get_environment(&self, path: Option<String>) -> Vec<String> {
+        let mut env_exists = false;
+        let mut env: Vec<String> = self
+            .env
+            .iter()
+            .map(|(k, v)| {
+                if k == "PATH" {
+                    env_exists = true;
+                }
+                format!("{k}={v}")
+            })
+            .collect();
+        // It is not possible in normal flow that path is None. The original container
+        // creation would have failed if path was absent. However we use Option
+        // just as a caution, and if neither exec cmd not original spec has PATH,
+        // the container creation will fail later which is ok
+        if let Some(p) = path {
+            if !env_exists {
+                env.push(p);
+            }
+        }
+        env
     }
 
     fn get_no_new_privileges(&self) -> Option<bool> {

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::{env, fs, mem};
@@ -761,6 +761,9 @@ fn set_supplementary_gids(
 
         let gids: Vec<Gid> = additional_gids
             .iter()
+            // this is to remove duplicate ids, so we behave similar to runc
+            .collect::<HashSet<_>>()
+            .into_iter()
             .map(|gid| Gid::from_raw(*gid))
             .collect();
 


### PR DESCRIPTION
This PR does following fixes:

1. Fix gid duplication in additional_gids : if we provide duplicate gid, runc simply ignore it, whereas we used to retain duplicates and create two distinct groups with same gid. Now we filter the duplicates and only set unique gids
2. Fix additional_gid, user, group not getting set in exec : exec command accepts these as args, but we did not use them in tenant container. Now we use them as well.
3. Inject `PATH` from original container in case not provided to exec : exec allows supplying env vars, but by default it does not set any. This causes issue when running exec directly via youki, as it would error with `PATH is not set` . Given that we are exec-ing into an existing container, the expectation would be the same env would be applied, or atleast the path would be taken from it. I guess any higher runtime (docker/podman) automatically sets envs from original container, but I have injected path if missing.


I want to also add tests for these, but wanted to get a review on the changes before that.