### PR TITLE
fix duplicate gids in container creation

### DIFF
--- a/crates/libcontainer/src/syscall/test.rs
+++ b/crates/libcontainer/src/syscall/test.rs
@@ -369,13 +369,13 @@ impl TestHelperSyscall {
             .collect::<Vec<String>>()
     }
 
-    pub fn get_groups_args(&self) -> Vec<Vec<Gid>> {
+    pub fn get_groups_args(&self) -> Vec<Gid> {
         self.mocks
             .fetch(ArgName::Groups)
             .values
             .iter()
-            .map(|x| x.downcast_ref::<Vec<Gid>>().unwrap().clone())
-            .collect::<Vec<Vec<Gid>>>()
+            .flat_map(|x| x.downcast_ref::<Vec<Gid>>().unwrap().clone())
+            .collect::<Vec<Gid>>()
     }
 
     pub fn get_io_priority_args(&self) -> Vec<IoPriorityArgs> {


### PR DESCRIPTION
When we provide duplicate gids in additional_gids runc simply ignores them, we should do the same. This PR fixes it and adds an e2e for the same.

Carried over from https://github.com/youki-dev/youki/pull/3018