### PR TITLE
Use later stable rust version 1.81.0 to fix the CI

### DIFF
--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -132,10 +132,7 @@ pub fn parse_env(envs: &[String]) -> HashMap<String, String> {
 
 /// Get a nix::unistd::User via UID. Potential errors will be ignored.
 pub fn get_unix_user(uid: Uid) -> Option<User> {
-    match User::from_uid(uid) {
-        Ok(x) => x,
-        Err(_) => None,
-    }
+    User::from_uid(uid).unwrap_or_default()
 }
 
 /// Get home path of a User via UID.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile="default"
-channel="1.80.0"
+channel="1.81.0"


### PR DESCRIPTION
This PR bumps the rust toolchain version to 1.81.0 to pass the CI failing due to the following error.

```
error: failed to compile `cross v0.2.5 (https://github.com/cross-rs/cross#4090beca)`, intermediate artifacts can be found at `/tmp/cargo-installPBmzPf`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.80.0 is not supported by the following package:
    home@0.5.11 requires rustc 1.81
  Either upgrade rustc or select compatible dependency versions with
  `cargo update <name>@<current-ver> --precise <compatible-ver>`
  where `<compatible-ver>` is the latest version supporting rustc 1.80.0
```

I've briefly checked the compatibility notes section of the release note, but I don't think bumping up the version would affect the youki's code base.

https://releases.rs/docs/1.81.0/#compatibility-notes