### PR TITLE
Use selinux.format_mount_label when formatting mount label

### DIFF
--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -51,6 +51,7 @@ thiserror = "2.0.9"
 tracing = { version = "0.1.41", features = ["attributes"] }
 safe-path = "0.1.0"
 nc = "0.9.5"
+selinux = { path = "../../experiment/selinux" }
 
 [dev-dependencies]
 oci-spec = { version = "~0.7.1", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -12,6 +12,7 @@ use oci_spec::runtime::{
     IOPriorityClass, LinuxIOPriority, LinuxNamespaceType, LinuxSchedulerFlag, LinuxSchedulerPolicy,
     Scheduler, Spec, User,
 };
+use selinux::selinux;
 
 use super::args::{ContainerArgs, ContainerType};
 use crate::error::MissingSpecError;
@@ -164,7 +165,7 @@ fn masked_path(path: &Path, mount_label: &Option<String>, syscall: &dyn Syscall)
             }
             SyscallError::Nix(nix::errno::Errno::ENOTDIR) => {
                 let label = match mount_label {
-                    Some(l) => format!("context=\"{l}\""),
+                    Some(l) => selinux::SELinux::format_mount_label("", l),
                     None => "".to_string(),
                 };
                 syscall

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -17,6 +17,7 @@ use nix::NixPath;
 use oci_spec::runtime::{Mount as SpecMount, MountBuilder as SpecMountBuilder};
 use procfs::process::{MountInfo, MountOptFields, Process};
 use safe_path;
+use selinux::selinux;
 
 #[cfg(feature = "v1")]
 use super::symlink::Symlink;
@@ -489,10 +490,7 @@ impl Mount {
 
         if let Some(l) = label {
             if typ != Some("proc") && typ != Some("sysfs") {
-                match mount_option_config.data.is_empty() {
-                    true => d = format!("context=\"{l}\""),
-                    false => d = format!("{},context=\"{}\"", mount_option_config.data, l),
-                }
+                d = selinux::SELinux::format_mount_label(&mount_option_config.data, l);
             }
         }
 


### PR DESCRIPTION
Previously, the mount label was formatted without using the SELinux library.
However, since the SELinux library was implemented in Rust, we can use it for formatting the mount label.
Therefore, in this PR, SELinux.format_mount_label is used.

This PR is related to the issue #2718 