### PR TITLE
Don't specify the versionFile for tagpr

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -1,7 +1,7 @@
 [tagpr]
     vPrefix = true
     releaseBranch = main
-    versionFile = .tagpr
+    versionFile = -
     command = just version-up 0.5.0
     release = false
     changelog = true


### PR DESCRIPTION
It looks like we don't need to specify because the release versions should be synced with git tags.
https://github.com/Songmu/tagpr#tagprversionfile