### PR TITLE
add process rlimits fail test

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -25,6 +25,7 @@ use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::process::get_process_test;
 use crate::tests::process_oom_score_adj::get_process_oom_score_adj_test;
 use crate::tests::process_rlimits::get_process_rlimits_test;
+use crate::tests::process_rlimits_fail::get_process_rlimits_fail_test;
 use crate::tests::process_user::get_process_user_test;
 use crate::tests::readonly_paths::get_ro_paths_test;
 use crate::tests::root_readonly_true::get_root_readonly_test;
@@ -124,6 +125,7 @@ fn main() -> Result<()> {
     let process = get_process_test();
     let process_user = get_process_user_test();
     let process_rlimtis = get_process_rlimits_test();
+    let process_rlimits_fail = get_process_rlimits_fail_test();
     let no_pivot = get_no_pivot_test();
     let process_oom_score_adj = get_process_oom_score_adj_test();
     let fd_control = get_fd_control_test();
@@ -154,6 +156,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(process));
     tm.add_test_group(Box::new(process_user));
     tm.add_test_group(Box::new(process_rlimtis));
+    tm.add_test_group(Box::new(process_rlimits_fail));
     tm.add_test_group(Box::new(no_pivot));
     tm.add_test_group(Box::new(process_oom_score_adj));
     tm.add_test_group(Box::new(fd_control));

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -15,6 +15,7 @@ pub mod pidfile;
 pub mod process;
 pub mod process_oom_score_adj;
 pub mod process_rlimits;
+pub mod process_rlimits_fail;
 pub mod process_user;
 pub mod readonly_paths;
 pub mod root_readonly_true;

--- a/tests/contest/contest/src/tests/process_rlimits_fail/mod.rs
+++ b/tests/contest/contest/src/tests/process_rlimits_fail/mod.rs
@@ -1,0 +1,2 @@
+mod process_rlimits_fail_test;
+pub use process_rlimits_fail_test::get_process_rlimits_fail_test;

--- a/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
+++ b/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
@@ -16,6 +16,10 @@ use crate::utils::test_utils::CreateOptions;
 /// - Sets its value to u64::MAX, which exceeds the system's maximum allowed value
 ///   defined in /proc/sys/fs/nr_open
 /// - This causes the kernel to reject the value with EPERM
+///
+/// See `man 2 setrlimit` for more details:
+/// > EPERM The caller tried to increase the hard RLIMIT_NOFILE limit above
+/// > the maximum defined by /proc/sys/fs/nr_open
 fn create_spec() -> Result<Spec> {
     let invalid_rlimit = PosixRlimitBuilder::default()
         .typ(PosixRlimitType::RlimitNofile)

--- a/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
+++ b/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
@@ -1,0 +1,50 @@
+use anyhow::{anyhow, Context, Result};
+use oci_spec::runtime::{PosixRlimitBuilder, PosixRlimitType, ProcessBuilder, Spec, SpecBuilder};
+use test_framework::{test_result, Test, TestGroup, TestResult};
+
+use crate::utils::test_inside_container;
+use crate::utils::test_utils::CreateOptions;
+
+fn create_spec() -> Result<Spec> {
+    let invalid_rlimit = PosixRlimitBuilder::default()
+        .typ(PosixRlimitType::RlimitNofile)
+        .hard(u64::MAX)
+        .soft(u64::MAX)
+        .build()?;
+
+    let spec = SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec![
+                    "runtimetest".to_string(),
+                    "process_rlimits".to_string(),
+                ])
+                .rlimits(vec![invalid_rlimit])
+                .build()
+                .context("failed to create process config")?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    Ok(spec)
+}
+
+fn process_rlimits_fail_test() -> TestResult {
+    let spec = test_result!(create_spec());
+    match test_inside_container(spec, &CreateOptions::default(), &|_| Ok(())) {
+        TestResult::Passed => TestResult::Failed(anyhow!(
+            "expected test with invalid rlimit value to fail, but it passed instead"
+        )),
+        _ => TestResult::Passed,
+    }
+}
+
+pub fn get_process_rlimits_fail_test() -> TestGroup {
+    let mut test_group = TestGroup::new("process_rlimits_fail");
+    let test = Test::new(
+        "process_rlimits_fail_test",
+        Box::new(process_rlimits_fail_test),
+    );
+    test_group.add(vec![Box::new(test)]);
+    test_group
+}

--- a/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
+++ b/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
@@ -20,6 +20,7 @@ use crate::utils::test_utils::CreateOptions;
 /// See `man 2 setrlimit` for more details:
 /// > EPERM The caller tried to increase the hard RLIMIT_NOFILE limit above
 /// > the maximum defined by /proc/sys/fs/nr_open
+/// > See also: https://docs.kernel.org/admin-guide/sysctl/fs.html#nr-open
 fn create_spec() -> Result<Spec> {
     let invalid_rlimit = PosixRlimitBuilder::default()
         .typ(PosixRlimitType::RlimitNofile)

--- a/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
+++ b/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
@@ -19,8 +19,8 @@ use crate::utils::test_utils::CreateOptions;
 fn create_spec() -> Result<Spec> {
     let invalid_rlimit = PosixRlimitBuilder::default()
         .typ(PosixRlimitType::RlimitNofile)
-        .hard(u64::MAX)  // Exceeds /proc/sys/fs/nr_open limit
-        .soft(u64::MAX)  // Exceeds /proc/sys/fs/nr_open limit
+        .hard(u64::MAX) // Exceeds /proc/sys/fs/nr_open limit
+        .soft(u64::MAX) // Exceeds /proc/sys/fs/nr_open limit
         .build()?;
 
     let spec = SpecBuilder::default()


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Implement integration test for process_rlimits_fail.
Port the test from runtime-tools/validation with a different approach.

While the original test in `runtime-tools/validation/process_rlimits_fail/process_rlimits_fail.go` tests by passing an invalid rlimits type (`RLIMIT_TEST`), this implementation takes a different approach since PosixRlimitBuilder uses a strictly typed enum (PosixRlimitType) that prevents invalid types at compile time.

Instead, this test validates the error handling by setting extremely high values (`u64::MAX`) for both hard and soft limits, which exceeds system limitations.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
related #361 (process_rlimits_fail)
