### PR TITLE
Remove problematic comments between package name in apt install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,8 +14,9 @@ EOF
 
 RUN <<EOF
 apt-get update
+
+# For building
 apt-get install -y \
-  # For building
   build-essential \
   git \
   libclang-dev \
@@ -23,10 +24,12 @@ apt-get install -y \
   libseccomp-dev \
   libssl-dev \
   libsystemd-dev \
-  pkg-config \
-  # For debugging
-  bpftrace \
-  podman
+  pkg-config
+
+# For debugging
+apt-get install -y \
+  podman \
+  bpftrace
 
 curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This PR fixes an issue where several packages are not installed properly because of syntax error by unintended comments.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

1. Open VSCode and press Cmd+Shift+P
2. Type and click "Dev Containers: Rebuild Container Without Cache"
3. Create a devcontainer after checking out this PR's branch
4. Run `just clean` and `cargo clean`
5. Run `just lint` and check it completes properly.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->

In devcontainer, we cannot build youki because of the following error.

<details><summary>Build error when executing `just lint`</summary>

```
error: failed to run custom build command for `libbpf-sys v1.5.0+v1.5.0`

Caused by:
  process didn't exit successfully: `/workspaces/youki/target/debug/build/libbpf-sys-29d574c8a895b7b8/build-script-build` (exit status: 101)
  --- stdout
  Using feature vendored-libbpf=true
  Using feature vendored-libelf=false
  Using feature vendored-zlib=false
  Using feature static-libbpf=true
  Using feature static-libelf=false
  Using feature static-zlib=false
  OPT_LEVEL = Some(0)
  TARGET = Some(aarch64-unknown-linux-gnu)
  OUT_DIR = Some(/workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out)
  HOST = Some(aarch64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CC_aarch64-unknown-linux-gnu
  CC_aarch64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_aarch64_unknown_linux_gnu
  CC_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  CARGO_CFG_TARGET_FEATURE = Some(neon)
  cargo:rerun-if-env-changed=CFLAGS_aarch64-unknown-linux-gnu
  CFLAGS_aarch64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_aarch64_unknown_linux_gnu
  CFLAGS_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=LIBBPF_SYS_EXTRA_CFLAGS
    MKDIR    /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs
    INSTALL  bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h bpf_helpers.h bpf_helper_defs.h bpf_tracing.h bpf_endian.h bpf_core_read.h skel_internal.h libbpf_version.h usdt.bpf.h
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/bpf.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/btf.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/libbpf.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/netlink.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/nlattr.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/str_error.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/bpf_prog_linfo.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/libbpf_errno.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/libbpf_probes.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/btf_dump.o
    CC       /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/hashmap.o

  --- stderr
  Package libelf was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libelf.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'libelf' found
  In file included from bpf.c:37:
  libbpf_internal.h:20:10: fatal error: libelf.h: No such file or directory
     20 | #include <libelf.h>
        |          ^~~~~~~~~~
  In file included from nlattr.c:14:
  libbpf_internal.h:20:10: fatal error: libelf.h: No such file or directory
     20 | #include <libelf.h>
        |          ^~~~~~~~~~
  compilation terminated.
  compilation terminated.
  btf.c:18:10: fatal error: gelf.h: No such file or directory
     18 | #include <gelf.h>
        |          ^~~~~~~~
  compilation terminated.
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/bpf.o] Error 1
  make: *** Waiting for unfinished jobs....
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/btf.o] Error 1
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/nlattr.o] Error 1
  In file included from bpf_prog_linfo.c:9:
  libbpf_internal.h:20:10: fatal error: libelf.h: No such file or directory
     20 | #include <libelf.h>
        |          ^~~~~~~~~~
  compilation terminated.
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/bpf_prog_linfo.o] Error 1
  libbpf.c:46:10: fatal error: libelf.h: No such file or directory
     46 | #include <libelf.h>
        |          ^~~~~~~~~~
  compilation terminated.
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/libbpf.o] Error 1
  In file included from netlink.c:19:
  libbpf_internal.h:20:10: fatal error: libelf.h: No such file or directory
     20 | #include <libelf.h>
        |          ^~~~~~~~~~
  compilation terminated.
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/netlink.o] Error 1
  In file included from libbpf_errno.c:15:
  libbpf_internal.h:20:10: fatal error: libelf.h: No such file or directory
     20 | #include <libelf.h>
        |          ^~~~~~~~~~
  compilation terminated.
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/libbpf_errno.o] Error 1
  In file included from libbpf_probes.c:19:
  libbpf_internal.h:20:10: fatal error: libelf.h: No such file or directory
     20 | #include <libelf.h>
        |          ^~~~~~~~~~
  compilation terminated.
  In file included from btf_dump.c:23:
  libbpf_internal.h:20:10: fatal error: libelf.h: No such file or directory
     20 | #include <libelf.h>
        |          ^~~~~~~~~~
  compilation terminated.
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/libbpf_probes.o] Error 1
  make: *** [Makefile:134: /workspaces/youki/target/aarch64-unknown-linux-gnu/debug/build/libbpf-sys-9d921a874c62a25e/out/obj/staticobjs/btf_dump.o] Error 1
  thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/libbpf-sys-1.5.0+v1.5.0/build.rs:384:5:
  make failed
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: Recipe `lint` failed on line 130 with exit code 101
```

</details>

After I looked into the container, I've found that required packages were not installed properly even though they're specified in the Dockerfile.

```
vscode ➜ /workspaces/youki (main) $ sudo apt list | grep -e "libclang-dev" -e "libelf-dev" -e "libseccomp-dev" -e "libsystemd-d
ev" -e "bpftrace" -e "podman"

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

This seems probably because of the comments in the middle of the heredoc part.

```
...
RUN <<EOF
apt-get update
apt-get install -y \
  # For building        <-- syntaxtically wrong
  build-essential \
  git \
  libclang-dev \
  libelf-dev \
  libseccomp-dev \
  libssl-dev \
  libsystemd-dev \
  pkg-config \
  # For debugging        <-- syntaxtically wrong
  bpftrace \
  podman
...
```

<details><summary>execution result of the problematic part</summary>

```
vscode ➜ /workspaces/youki (main) $ apt-get install -y \
  # For building
  build-essential \
  git \
  libclang-dev \
  libelf-dev \
  libseccomp-dev \
  libssl-dev \
  libsystemd-dev \
  pkg-config \
  # For debugging
  bpftrace \
  podman
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
bash: build-essential: command not found
bash: bpftrace: command not found
```

</details>

The built image should be equivalent even after splitting package installation into two lines as they're in the single heredoc. This PR splits a heredoc part including installation commands so that we can easily see which packages would be intended to be installed for what.

## Additional Context
<!-- Add any other context about the pull request here -->
