### PR TITLE
Make `sepc` into `&spec` in test_{outside,inside}_containe

### DIFF
--- a/tests/contest/contest/src/tests/cgroups/blkio.rs
+++ b/tests/contest/contest/src/tests/cgroups/blkio.rs
@@ -544,7 +544,7 @@ fn test_blkio(test_name: &str, rate: u64, empty: bool) -> TestResult {
     )
     .unwrap();
 
-    test_outside_container(spec.clone(), &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(validate_block_io(test_name, &spec));
         TestResult::Passed

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -205,7 +205,7 @@ fn test_cpu_cgroups() -> TestResult {
 
     for case in cases.into_iter() {
         let spec = test_result!(create_spec(cgroup_name, case));
-        let test_result = test_outside_container(spec, &|data| {
+        let test_result = test_outside_container(&spec, &|data| {
             test_result!(check_container_created(&data));
 
             TestResult::Passed
@@ -223,7 +223,7 @@ fn test_empty_cpu() -> TestResult {
     let cgroup_name = "test_empty_cpu";
     let spec = test_result!(create_empty_spec(cgroup_name));
 
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         TestResult::Passed
     })
@@ -249,7 +249,7 @@ fn test_cpu_idle_set() -> TestResult {
     ));
 
     let spec = test_result!(create_spec(cgroup_name, cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         TestResult::Passed
     })
@@ -273,7 +273,7 @@ fn test_cpu_idle_default() -> TestResult {
         realtime_runtime,
     ));
     let spec = test_result!(create_spec(cgroup_name, cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         TestResult::Passed
     })

--- a/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
@@ -35,7 +35,7 @@ fn test_cpu_idle_set() -> TestResult {
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_idle_set", cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_set", idle));
         TestResult::Passed
@@ -48,7 +48,7 @@ fn test_cpu_idle_default() -> TestResult {
     let cpu = test_result!(LinuxCpuBuilder::default().build().context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_idle_default", cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_default", default_idle));
         TestResult::Passed
@@ -65,7 +65,7 @@ fn test_cpu_weight_valid_set() -> TestResult {
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_weight_valid_set", cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
             "test_cpu_weight_valid_set",
@@ -85,7 +85,7 @@ fn test_cpu_weight_zero_ignored() -> TestResult {
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_weight_zero_ignored", cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
             "test_cpu_weight_zero_ignored",
@@ -105,7 +105,7 @@ fn test_cpu_weight_too_high_maximum_set() -> TestResult {
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_weight_too_high_maximum_set", cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_weight(
             "test_cpu_weight_too_high_maximum_set",
@@ -124,7 +124,7 @@ fn test_cpu_quota_valid_set() -> TestResult {
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_quota_valid_set", cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
             "test_cpu_quota_valid_set",
@@ -144,7 +144,7 @@ fn test_cpu_quota_zero_default_set() -> TestResult {
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_quota_zero_default_set", cpu));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
             "test_cpu_quota_zero_default_set",
@@ -167,7 +167,7 @@ fn test_cpu_quota_negative_default_set() -> TestResult {
         "test_cpu_quota_negative_value_default_set",
         cpu
     ));
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
             "test_cpu_quota_negative_value_default_set",
@@ -195,7 +195,7 @@ fn test_cpu_period_valid_set() -> TestResult {
         &expected_period.to_string()
     ));
 
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
             "test_cpu_period_valid_set",
@@ -220,7 +220,7 @@ fn test_cpu_quota_period_unspecified_unchanged() -> TestResult {
         &expected_period.to_string()
     ));
 
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
             "test_cpu_period_unspecified_unchanged",
@@ -242,7 +242,7 @@ fn test_cpu_period_and_quota_valid_set() -> TestResult {
 
     let spec = test_result!(create_spec("test_cpu_period_and_quota_valid_set", cpu));
 
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_max(
             "test_cpu_period_and_quota_valid_set",

--- a/tests/contest/contest/src/tests/cgroups/memory.rs
+++ b/tests/contest/contest/src/tests/cgroups/memory.rs
@@ -51,7 +51,7 @@ fn test_memory_cgroups() -> TestResult {
     ];
 
     for spec in cases.into_iter() {
-        let test_result = test_outside_container(spec, &|data| {
+        let test_result = test_outside_container(&spec, &|data| {
             test_result!(check_container_created(&data));
 
             TestResult::Passed

--- a/tests/contest/contest/src/tests/cgroups/network.rs
+++ b/tests/contest/contest/src/tests/cgroups/network.rs
@@ -115,7 +115,7 @@ fn test_network_cgroups() -> TestResult {
     ];
 
     for spec in cases.into_iter() {
-        let test_result = test_outside_container(spec, &|data| {
+        let test_result = test_outside_container(&spec, &|data| {
             test_result!(check_container_created(&data));
 
             TestResult::Passed

--- a/tests/contest/contest/src/tests/cgroups/pids.rs
+++ b/tests/contest/contest/src/tests/cgroups/pids.rs
@@ -42,7 +42,7 @@ fn test_positive_limit() -> TestResult {
     let limit = 50;
     let spec = test_result!(create_spec(cgroup_name, limit));
 
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_pid_limit_set(cgroup_name, limit));
         TestResult::Passed
@@ -55,7 +55,7 @@ fn test_zero_limit() -> TestResult {
     let limit = 0;
     let spec = test_result!(create_spec(cgroup_name, limit));
 
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_pids_are_unlimited(cgroup_name));
         TestResult::Passed
@@ -68,7 +68,7 @@ fn test_negative_limit() -> TestResult {
     let limit = -1;
     let spec = test_result!(create_spec(cgroup_name, limit));
 
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_pids_are_unlimited(cgroup_name));
         TestResult::Passed

--- a/tests/contest/contest/src/tests/devices/devices_test.rs
+++ b/tests/contest/contest/src/tests/devices/devices_test.rs
@@ -60,7 +60,7 @@ fn create_spec() -> Result<Spec> {
 
 fn devices_test() -> TestResult {
     let spec = test_result!(create_spec());
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_devices_test() -> TestGroup {

--- a/tests/contest/contest/src/tests/domainname/mod.rs
+++ b/tests/contest/contest/src/tests/domainname/mod.rs
@@ -22,7 +22,7 @@ fn get_spec(domainname: &str) -> Spec {
 
 fn set_domainname_test() -> TestResult {
     let spec = get_spec("domainname");
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_domainname_tests() -> TestGroup {

--- a/tests/contest/contest/src/tests/example/hello_world.rs
+++ b/tests/contest/contest/src/tests/example/hello_world.rs
@@ -26,7 +26,7 @@ fn create_spec() -> Result<Spec> {
 ////////// ANCHOR: example_test
 fn example_test() -> TestResult {
     let spec = test_result!(create_spec());
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 ////////// ANCHOR_END: example_test
 

--- a/tests/contest/contest/src/tests/fd_control/mod.rs
+++ b/tests/contest/contest/src/tests/fd_control/mod.rs
@@ -40,7 +40,7 @@ fn open_devnull_no_cloexec() -> Result<(fs::File, RawFd)> {
 fn only_stdio_test() -> TestResult {
     let spec = test_result!(create_spec());
     test_inside_container(
-        spec,
+        &spec,
         &CreateOptions::default().with_extra_args(&["--preserve-fds".as_ref(), "100".as_ref()]),
         &|bundle_path| {
             fs::write(bundle_path.join("num-fds"), "0".as_bytes())?;
@@ -60,7 +60,7 @@ fn closes_fd_test() -> TestResult {
 
     let spec = test_result!(create_spec());
     test_inside_container(
-        spec,
+        &spec,
         &CreateOptions::default().with_extra_args(&["--preserve-fds".as_ref(), "0".as_ref()]),
         &|bundle_path| {
             fs::write(bundle_path.join("num-fds"), "0".as_bytes())?;
@@ -79,7 +79,7 @@ fn pass_single_fd_test() -> TestResult {
 
     let spec = test_result!(create_spec());
     test_inside_container(
-        spec,
+        &spec,
         &CreateOptions::default().with_extra_args(&[
             "--preserve-fds".as_ref(),
             (devnull_fd - 2).to_string().as_ref(), // relative to stdio

--- a/tests/contest/contest/src/tests/hostname/mod.rs
+++ b/tests/contest/contest/src/tests/hostname/mod.rs
@@ -26,7 +26,7 @@ fn create_spec(hostname: &str) -> Spec {
 
 fn hostname_test() -> TestResult {
     let spec = create_spec("hostname-specific");
-    test_inside_container(spec, &CreateOptions::default(), &|_| {
+    test_inside_container(&spec, &CreateOptions::default(), &|_| {
         // As long as the container is created, we expect the hostname to be determined
         // by the spec, so nothing to prepare prior.
         Ok(())
@@ -35,7 +35,7 @@ fn hostname_test() -> TestResult {
 
 fn empty_hostname() -> TestResult {
     let spec = create_spec("");
-    test_inside_container(spec, &CreateOptions::default(), &|_| {
+    test_inside_container(&spec, &CreateOptions::default(), &|_| {
         // As long as the container is created, we expect the hostname to be determined
         // by the spec, so nothing to prepare prior.
         Ok(())

--- a/tests/contest/contest/src/tests/intel_rdt/intel_rdt_test.rs
+++ b/tests/contest/contest/src/tests/intel_rdt/intel_rdt_test.rs
@@ -40,7 +40,7 @@ pub fn test_intel_rdt() -> TestResult {
     ];
 
     for spec in cases.into_iter() {
-        let test_result = test_outside_container(spec, &|data| {
+        let test_result = test_outside_container(&spec, &|data| {
             test_result!(check_container_created(&data));
 
             TestResult::Passed

--- a/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
+++ b/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
@@ -39,7 +39,7 @@ fn io_priority_class_rt_test() -> TestResult {
         "io_priority_class_rt",
         1,
     ));
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 fn io_priority_class_be_test() -> TestResult {
@@ -48,7 +48,7 @@ fn io_priority_class_be_test() -> TestResult {
         "io_priority_class_be",
         2,
     ));
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 fn io_priority_class_idle_test() -> TestResult {
@@ -57,7 +57,7 @@ fn io_priority_class_idle_test() -> TestResult {
         "io_priority_class_idle",
         3,
     ));
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_io_priority_test() -> TestGroup {

--- a/tests/contest/contest/src/tests/linux_ns_itype/ns_itype_test.rs
+++ b/tests/contest/contest/src/tests/linux_ns_itype/ns_itype_test.rs
@@ -44,7 +44,7 @@ fn get_test(test_name: &'static str) -> Test {
                 }
             };
             let spec = get_spec();
-            test_outside_container(spec, &move |data| {
+            test_outside_container(&spec, &move |data| {
                 let pid = match data.state {
                     Some(s) => s.pid.unwrap(),
                     None => return TestResult::Failed(anyhow!("state command returned error")),

--- a/tests/contest/contest/src/tests/mounts_recursive/mod.rs
+++ b/tests/contest/contest/src/tests/mounts_recursive/mod.rs
@@ -113,7 +113,7 @@ fn check_recursive_readonly() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| {
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| {
         setup_mount(&rro_dir_path, &rro_subdir_path);
         Ok(())
     });
@@ -153,7 +153,7 @@ fn check_recursive_nosuid() -> TestResult {
         ],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         setup_mount(&rnosuid_dir_path, &rnosuid_subdir_path);
 
         let executable_file_path = bundle_path.join("bin").join(executable_file_name);
@@ -226,7 +226,7 @@ fn check_recursive_rsuid() -> TestResult {
         vec![mount_spec],
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
-    test_inside_container(spec, &CreateOptions::default(), &|_| {
+    test_inside_container(&spec, &CreateOptions::default(), &|_| {
         let original_file_path = rsuid_dir_path.join("file");
         let file = File::create(original_file_path)?;
         let mut permission = file.metadata()?.permissions();
@@ -257,7 +257,7 @@ fn check_recursive_noexec() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         setup_mount(&rnoexec_dir_path, &rnoexec_subdir_path);
 
         let executable_file_name = "echo";
@@ -298,7 +298,7 @@ fn check_recursive_rexec() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         setup_mount(&rnoexec_dir_path, &rnoexec_subdir_path);
 
         let executable_file_name = "echo";
@@ -339,7 +339,7 @@ fn check_recursive_rdiratime() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()));
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()));
 
     fs::remove_dir(rdiratime_base_dir).unwrap();
     result
@@ -363,7 +363,7 @@ fn check_recursive_rnodiratime() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()));
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()));
     fs::remove_dir(rnodiratime_base_dir).unwrap();
     result
 }
@@ -384,7 +384,7 @@ fn check_recursive_rdev() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 fn check_recursive_rnodev() -> TestResult {
@@ -403,7 +403,7 @@ fn check_recursive_rnodev() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 fn check_recursive_readwrite() -> TestResult {
@@ -424,7 +424,7 @@ fn check_recursive_readwrite() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| {
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| {
         setup_mount(&rrw_dir_path, &rrw_subdir_path);
         Ok(())
     });
@@ -452,7 +452,7 @@ fn check_recursive_rrelatime() -> TestResult {
         vec![mount_spec],
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()));
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()));
 
     fs::remove_dir_all(rrelatime_dir_path).unwrap();
     result
@@ -476,7 +476,7 @@ fn check_recursive_rnorelatime() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()));
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()));
 
     fs::remove_dir_all(rnorelatime_dir_path).unwrap();
     result
@@ -500,7 +500,7 @@ fn check_recursive_rnoatime() -> TestResult {
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
 
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()));
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()));
 
     fs::remove_dir_all(rnoatime_dir_path).unwrap();
     result
@@ -523,7 +523,7 @@ fn check_recursive_rstrictatime() -> TestResult {
         vec![mount_spec],
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()));
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()));
 
     fs::remove_dir_all(rstrictatime_dir_path).unwrap();
     result
@@ -549,7 +549,7 @@ fn check_recursive_rnosymfollow() -> TestResult {
         vec![mount_spec],
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| {
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| {
         let original_file_path = format!("{}/{}", rnosymfollow_dir_path.to_str().unwrap(), "file");
         let file = File::create(&original_file_path)?;
         let link_file_path = format!("{}/{}", rnosymfollow_dir_path.to_str().unwrap(), "link");
@@ -588,7 +588,7 @@ fn check_recursive_rsymfollow() -> TestResult {
         vec![mount_spec],
         vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
     );
-    let result = test_inside_container(spec, &CreateOptions::default(), &|_| {
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| {
         let original_file_path = format!("{}/{}", rsymfollow_dir_path.to_str().unwrap(), "file");
         let file = File::create(&original_file_path)?;
         let link_file_path = format!("{}/{}", rsymfollow_dir_path.to_str().unwrap(), "link");

--- a/tests/contest/contest/src/tests/no_pivot/mod.rs
+++ b/tests/contest/contest/src/tests/no_pivot/mod.rs
@@ -18,7 +18,7 @@ fn create_spec() -> Result<Spec> {
 fn no_pivot_test() -> TestResult {
     let spec = test_result!(create_spec());
     test_inside_container(
-        spec,
+        &spec,
         &CreateOptions::default().with_no_pivot_root(),
         &|_| Ok(()),
     )

--- a/tests/contest/contest/src/tests/process/process_test.rs
+++ b/tests/contest/contest/src/tests/process/process_test.rs
@@ -29,7 +29,7 @@ fn create_spec() -> Result<Spec> {
 fn process_test() -> TestResult {
     let spec = test_result!(create_spec());
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle| {
         match fs::create_dir(bundle.join("test")) {
             Result::Ok(_) => { /*This is expected*/ }
             Err(e) => {

--- a/tests/contest/contest/src/tests/process_oom_score_adj/process_oom_score_adj_test.rs
+++ b/tests/contest/contest/src/tests/process_oom_score_adj/process_oom_score_adj_test.rs
@@ -31,7 +31,7 @@ fn create_spec() -> Result<Spec> {
 
 fn process_oom_score_adj_test() -> TestResult {
     let spec = test_result!(create_spec());
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_process_oom_score_adj_test() -> TestGroup {

--- a/tests/contest/contest/src/tests/process_rlimits/process_rlimits_test.rs
+++ b/tests/contest/contest/src/tests/process_rlimits/process_rlimits_test.rs
@@ -55,7 +55,7 @@ fn create_spec() -> Result<Spec> {
 
 fn process_rlimits_test() -> TestResult {
     let spec = test_result!(create_spec());
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_process_rlimits_test() -> TestGroup {

--- a/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
+++ b/tests/contest/contest/src/tests/process_rlimits_fail/process_rlimits_fail_test.rs
@@ -47,7 +47,7 @@ fn create_spec() -> Result<Spec> {
 
 fn process_rlimits_fail_test() -> TestResult {
     let spec = test_result!(create_spec());
-    match test_inside_container(spec, &CreateOptions::default(), &|_| Ok(())) {
+    match test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(())) {
         TestResult::Passed => TestResult::Failed(anyhow!(
             "expected test with invalid rlimit value to fail, but it passed instead"
         )),

--- a/tests/contest/contest/src/tests/process_user/process_user_test.rs
+++ b/tests/contest/contest/src/tests/process_user/process_user_test.rs
@@ -46,7 +46,7 @@ fn create_spec(gids: Vec<u32>) -> Result<Spec> {
 fn process_user_test_unique_gids() -> TestResult {
     let gids = generate_unique_random_vec();
     let spec = test_result!(create_spec(gids));
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 fn process_user_test_duplicate_gids() -> TestResult {
@@ -54,7 +54,7 @@ fn process_user_test_duplicate_gids() -> TestResult {
     let duplicate = gids[0];
     gids.push(duplicate);
     let spec = test_result!(create_spec(gids));
-    match test_inside_container(spec, &CreateOptions::default(), &|_| Ok(())) {
+    match test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(())) {
         TestResult::Passed => TestResult::Failed(anyhow!(
             "expected test with duplicate gids to fail, but it passed instead"
         )),

--- a/tests/contest/contest/src/tests/readonly_paths/readonly_paths_tests.rs
+++ b/tests/contest/contest/src/tests/readonly_paths/readonly_paths_tests.rs
@@ -61,7 +61,7 @@ fn check_readonly_paths() -> TestResult {
     ];
 
     let spec = get_spec(ro_paths);
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::{fs, io};
         let test_dir = bundle_path.join(&ro_dir_sub);
 
@@ -112,7 +112,7 @@ fn check_readonly_rel_path() -> TestResult {
     let ro_paths = vec![ro_rel_path.to_string()];
     let spec = get_spec(ro_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::{fs, io};
         let test_file = bundle_path.join(ro_rel_path);
 
@@ -143,7 +143,7 @@ fn check_readonly_symlinks() -> TestResult {
 
     let spec = get_spec(ro_paths);
 
-    let res = test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    let res = test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::{fs, io};
         let test_file = bundle_path.join(ro_symlink);
 
@@ -194,7 +194,7 @@ fn test_node(mode: u32) -> TestResult {
 
     let spec = get_spec(ro_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::os::unix::fs::OpenOptionsExt;
         use std::{fs, io};
         let test_file = bundle_path.join(ro_device);

--- a/tests/contest/contest/src/tests/root_readonly_true/root_readonly_tests.rs
+++ b/tests/contest/contest/src/tests/root_readonly_true/root_readonly_tests.rs
@@ -22,12 +22,12 @@ fn create_spec(readonly: bool) -> Result<Spec> {
 
 fn root_readonly_true_test() -> TestResult {
     let spec_true = test_result!(create_spec(true));
-    test_inside_container(spec_true, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec_true, &CreateOptions::default(), &|_| Ok(()))
 }
 
 fn root_readonly_false_test() -> TestResult {
     let spec_false = test_result!(create_spec(false));
-    test_inside_container(spec_false, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec_false, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_root_readonly_test() -> TestGroup {

--- a/tests/contest/contest/src/tests/scheduler/scheduler_policy.rs
+++ b/tests/contest/contest/src/tests/scheduler/scheduler_policy.rs
@@ -34,7 +34,7 @@ fn scheduler_policy_other_test() -> TestResult {
         LinuxSchedulerPolicy::SchedOther,
         "scheduler_policy_other"
     ));
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 fn scheduler_policy_batch_test() -> TestResult {
@@ -42,7 +42,7 @@ fn scheduler_policy_batch_test() -> TestResult {
         LinuxSchedulerPolicy::SchedBatch,
         "scheduler_policy_batch"
     ));
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_scheduler_test() -> TestGroup {

--- a/tests/contest/contest/src/tests/seccomp/mod.rs
+++ b/tests/contest/contest/src/tests/seccomp/mod.rs
@@ -37,7 +37,7 @@ fn seccomp_test() -> TestResult {
             .build()
             .unwrap(),
     );
-    test_inside_container(spec, &CreateOptions::default(), &|_| Ok(()))
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
 pub fn get_seccomp_test() -> TestGroup {

--- a/tests/contest/contest/src/tests/seccomp_notify/mod.rs
+++ b/tests/contest/contest/src/tests/seccomp_notify/mod.rs
@@ -69,7 +69,7 @@ fn test_seccomp_notify() -> Result<()> {
             .send(res)
             .expect("failed to send seccomp agent result back to main thread");
     });
-    if let TestResult::Failed(err) = test_outside_container(spec, &move |data| {
+    if let TestResult::Failed(err) = test_outside_container(&spec, &move |data| {
         let (container_process_state, _) = receiver
             .recv()
             .expect("failed to receive from channel")

--- a/tests/contest/contest/src/tests/sysctl/mod.rs
+++ b/tests/contest/contest/src/tests/sysctl/mod.rs
@@ -29,7 +29,7 @@ fn sysctl_test() -> TestResult {
         "net.ipv4.ip_forward".to_string(),
         "1".to_string(),
     )]));
-    test_inside_container(spec, &CreateOptions::default(), &|_| {
+    test_inside_container(&spec, &CreateOptions::default(), &|_| {
         // As long as the container is created, we expect the kernel parameters to be determined by
         // the spec, so nothing to prepare prior.
         Ok(())

--- a/tests/contest/contest/src/tests/tlb/tlb_test.rs
+++ b/tests/contest/contest/src/tests/tlb/tlb_test.rs
@@ -53,7 +53,7 @@ fn test_wrong_tlb() -> TestResult {
     let page = "3MB";
     let limit = 100 * 3 * 1024 * 1024;
     let spec = make_hugetlb_spec(page, limit);
-    test_outside_container(spec, &|data| {
+    test_outside_container(&spec, &|data| {
         match data.create_result {
             Err(e) => TestResult::Failed(anyhow!(e)),
             Ok(res) => {
@@ -151,7 +151,7 @@ fn test_valid_tlb() -> TestResult {
     let tlb_sizes = get_tlb_sizes();
     for size in tlb_sizes.iter() {
         let spec = make_hugetlb_spec(size, limit);
-        let res = test_outside_container(spec, &|data| {
+        let res = test_outside_container(&spec, &|data| {
             test_result!(check_container_created(&data));
 
             let r = validate_tlb(&data.id, size, limit);
@@ -172,7 +172,7 @@ fn test_valid_rsvd_tlb() -> TestResult {
     let tlb_sizes = get_tlb_sizes();
     for size in tlb_sizes.iter() {
         let spec = make_hugetlb_spec(size, limit);
-        let res = test_outside_container(spec, &|data| {
+        let res = test_outside_container(&spec, &|data| {
             test_result!(check_container_created(&data));
             // Currentle, we write the same value to both limit_in_bytes and rsvd.limit_in_bytes
             let non_rsvd = validate_tlb(&data.id, size, limit);

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -145,13 +145,13 @@ fn runtime_command<P: AsRef<Path>>(dir: P) -> Command {
 }
 
 pub fn test_outside_container(
-    spec: Spec,
+    spec: &Spec,
     execute_test: &dyn Fn(ContainerData) -> TestResult,
 ) -> TestResult {
     let id = generate_uuid();
     let id_str = id.to_string();
     let bundle = prepare_bundle().unwrap();
-    set_config(&bundle, &spec).unwrap();
+    set_config(&bundle, spec).unwrap();
     let options = CreateOptions::default();
     let create_result = create_container(&id_str, &bundle, &options).unwrap().wait();
     let (out, err) = get_state(&id_str, &bundle).unwrap();
@@ -173,7 +173,7 @@ pub fn test_outside_container(
 
 // mostly needs a name that better expresses what this actually does
 pub fn test_inside_container(
-    spec: Spec,
+    spec: &Spec,
     options: &CreateOptions,
     setup_for_test: &dyn Fn(&Path) -> Result<()>,
 ) -> TestResult {
@@ -186,7 +186,7 @@ pub fn test_inside_container(
         &bundle.as_ref().join("bundle").join("rootfs")
     ));
 
-    set_config(&bundle, &spec).unwrap();
+    set_config(&bundle, spec).unwrap();
     // as we have to run runtimetest inside the container, and is expects
     // the config.json to be at path /config.json we save it there
     let path = bundle


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

We don't need to pass `spec`. Some test cases still continue to need ownership of `spec` after calling the test_{outside,inside}_container function. They don't require ownership of `spec`.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
None

## Additional Context
<!-- Add any other context about the pull request here -->
