### PR TITLE
lset_file_label should check for symlink instead of raw file

### DIFF
--- a/experiment/selinux/src/selinux_label.rs
+++ b/experiment/selinux/src/selinux_label.rs
@@ -91,7 +91,7 @@ impl SELinux {
         label: SELinuxLabel,
     ) -> Result<(), SELinuxError> {
         let path = fpath.as_ref();
-        if !path.exists() {
+        if !path.is_symlink() && !path.exists() {
             return Err(SELinuxError::LSetFileLabel(ERR_EMPTY_PATH.to_string()));
         }
 


### PR DESCRIPTION
## Description
In lset_file_label, we are setting SELinux context directly on the symlink itself, instead of the file it's pointing to. However, `path.exists()` function will actually traverse the symlink. In case of a broken symlink, it will report an error.
Note that this is common in container engines, where symlinks are only valid after the root has been switched.
This PR adds another check to first determine if a symlink exists at the given path.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

My amazing attention allowed me to directly observe the outcome and it's a correct implementation.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
