### PR TITLE
Add `delete` test

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -9,6 +9,7 @@ use contest::logger;
 use test_framework::TestManager;
 use tests::cgroups;
 
+use crate::tests::delete::get_delete_test;
 use crate::tests::devices::get_devices_test;
 use crate::tests::domainname::get_domainname_tests;
 use crate::tests::example::get_example_test;
@@ -121,6 +122,7 @@ fn main() -> Result<()> {
     let sysctl = get_sysctl_test();
     let scheduler = get_scheduler_test();
     let io_priority_test = get_io_priority_test();
+    let delete = get_delete_test();
     let devices = get_devices_test();
     let root_readonly = get_root_readonly_test();
     let process = get_process_test();
@@ -153,6 +155,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(intel_rdt));
     tm.add_test_group(Box::new(sysctl));
     tm.add_test_group(Box::new(scheduler));
+    tm.add_test_group(Box::new(delete));
     tm.add_test_group(Box::new(devices));
     tm.add_test_group(Box::new(root_readonly));
     tm.add_test_group(Box::new(process));

--- a/tests/contest/contest/src/tests/delete/delete_test.rs
+++ b/tests/contest/contest/src/tests/delete/delete_test.rs
@@ -1,0 +1,167 @@
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::tests::lifecycle::ContainerLifecycle;
+
+/// Test deleting a non-existent container
+fn delete_non_existed_container() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    match container.delete() {
+        TestResult::Failed(_) => TestResult::Passed,
+        TestResult::Passed => TestResult::Failed(anyhow!(
+            "Expected deleting a non-existent container to fail, but it succeeded"
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    }
+}
+
+/// Test deleting a container in "created" state
+fn delete_created_container_test() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    // Create the container
+    match container.create() {
+        TestResult::Passed => {}
+        _ => return TestResult::Failed(anyhow!("Failed to create container")),
+    }
+
+    // Wait for state transition
+    sleep(Duration::from_secs(1));
+
+    // Delete the container in "created" state
+    match container.delete() {
+        TestResult::Passed => TestResult::Passed,
+        TestResult::Failed(err) => TestResult::Failed(anyhow!(
+            "Failed to delete container in 'created' state: {}",
+            err
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    }
+}
+
+/// Test deleting a container in "running" state
+fn delete_running_container_test() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    // Create the container
+    match container.create() {
+        TestResult::Passed => {}
+        _ => return TestResult::Failed(anyhow!("Failed to create container")),
+    }
+
+    // Start the container
+    match container.start() {
+        TestResult::Passed => {}
+        _ => {
+            // Clean up and return error
+            let _ = container.kill();
+            sleep(Duration::from_secs(2));
+            let _ = container.delete();
+            return TestResult::Failed(anyhow!("Failed to start container"));
+        }
+    }
+
+    // Wait for running state
+    sleep(Duration::from_secs(2));
+
+    // Try to delete the running container (should fail per OCI spec)
+    let delete_result = match container.delete() {
+        TestResult::Failed(_) => TestResult::Passed,
+        TestResult::Passed => TestResult::Failed(anyhow!(
+            "Expected deleting a running container to fail, but it succeeded"
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    };
+
+    // Clean up
+    let _ = container.kill();
+    sleep(Duration::from_secs(2));
+    let cleanup_result = container.delete();
+
+    // Return test result
+    match delete_result {
+        TestResult::Passed => cleanup_result,
+        _ => delete_result,
+    }
+}
+
+/// Test deleting a container in "stopped" state
+fn delete_stopped_container_test() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    // Create the container
+    match container.create() {
+        TestResult::Passed => {}
+        _ => return TestResult::Failed(anyhow!("Failed to create container")),
+    }
+
+    // Start the container
+    match container.start() {
+        TestResult::Passed => {}
+        _ => {
+            // Clean up and return error
+            let _ = container.kill();
+            sleep(Duration::from_secs(2));
+            let _ = container.delete();
+            return TestResult::Failed(anyhow!("Failed to start container"));
+        }
+    }
+
+    // Stop the container
+    match container.kill() {
+        TestResult::Passed => {}
+        _ => {
+            // Clean up and return error
+            let _ = container.delete();
+            return TestResult::Failed(anyhow!("Failed to kill container"));
+        }
+    }
+
+    // Wait for stopped state
+    sleep(Duration::from_secs(2));
+
+    // Delete the stopped container
+    match container.delete() {
+        TestResult::Passed => TestResult::Passed,
+        TestResult::Failed(err) => TestResult::Failed(anyhow!(
+            "Expected deleting a stopped container to succeed, but it failed: {}",
+            err
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    }
+}
+
+/// Create and return the delete_container test group
+pub fn get_delete_test() -> TestGroup {
+    let mut test_group = TestGroup::new("delete");
+
+    let delete_non_existed_container = Test::new(
+        "delete_non_existed_container",
+        Box::new(delete_non_existed_container),
+    );
+    let delete_created_container_test = Test::new(
+        "delete_created_container_test",
+        Box::new(delete_created_container_test),
+    );
+    let delete_running_container_test = Test::new(
+        "delete_running_container_test",
+        Box::new(delete_running_container_test),
+    );
+    let delete_stopped_container_test = Test::new(
+        "delete_stopped_container_test",
+        Box::new(delete_stopped_container_test),
+    );
+
+    test_group.add(vec![
+        Box::new(delete_non_existed_container),
+        Box::new(delete_created_container_test),
+        Box::new(delete_running_container_test),
+        Box::new(delete_stopped_container_test),
+    ]);
+
+    test_group
+}

--- a/tests/contest/contest/src/tests/delete/mod.rs
+++ b/tests/contest/contest/src/tests/delete/mod.rs
@@ -1,0 +1,2 @@
+mod delete_test;
+pub use delete_test::get_delete_test;

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -86,6 +86,26 @@ impl ContainerLifecycle {
             &self.container_id,
         )
     }
+
+    /// Wait for the container to reach a specific state
+    pub fn wait_for_state(&self, expected_state: &str, timeout: Duration) -> TestResult {
+        use crate::tests::lifecycle::state;
+
+        match state::wait_for_state(
+            self.project_path.path(),
+            &self.container_id,
+            expected_state,
+            timeout,
+            Duration::from_millis(100),
+        ) {
+            Ok(_) => TestResult::Passed,
+            Err(e) => TestResult::Failed(anyhow::anyhow!(
+                "Container failed to reach {} state: {}",
+                expected_state,
+                e
+            )),
+        }
+    }
 }
 
 impl TestableGroup for ContainerLifecycle {

--- a/tests/contest/contest/src/tests/lifecycle/state.rs
+++ b/tests/contest/contest/src/tests/lifecycle/state.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
+use serde_json::Value;
 
 use crate::utils::get_state;
 
@@ -22,4 +23,79 @@ pub fn state(project_path: &Path, id: &str) -> Result<()> {
         }
         Err(e) => Err(e.context("failed to get container state")),
     }
+}
+
+/// Get the container status as a string
+pub fn get_container_status(project_path: &Path, id: &str) -> Result<String> {
+    match get_state(id, project_path) {
+        Ok((stdout, stderr)) => {
+            if stderr.contains("Error") || stderr.contains("error") {
+                bail!("Error :\nstdout : {}\nstderr : {}", stdout, stderr)
+            } else {
+                // Parse JSON to extract status
+                match serde_json::from_str::<Value>(&stdout) {
+                    Ok(value) => {
+                        if let Some(status) = value.get("status") {
+                            if let Some(status_str) = status.as_str() {
+                                return Ok(status_str.to_string());
+                            }
+                        }
+                        bail!("Failed to extract status from state output: {}", stdout)
+                    }
+                    Err(err) => bail!("Failed to parse state output as JSON: {} - {}", stdout, err),
+                }
+            }
+        }
+        Err(e) => Err(e.context("failed to get container state")),
+    }
+}
+
+/// Check if a container is in a specific state
+pub fn is_in_state(project_path: &Path, id: &str, expected_state: &str) -> Result<bool> {
+    match get_container_status(project_path, id) {
+        Ok(status) => Ok(status == expected_state),
+        Err(e) => {
+            // If the container doesn't exist, it's not in the expected state
+            if e.to_string().contains("does not exist") {
+                return Ok(false);
+            }
+            Err(e.context(format!(
+                "failed to check if container is in {} state",
+                expected_state
+            )))
+        }
+    }
+}
+
+/// Wait for a container to reach a specific state with timeout
+pub fn wait_for_state(
+    project_path: &Path,
+    id: &str,
+    expected_state: &str,
+    timeout: std::time::Duration,
+    poll_interval: std::time::Duration,
+) -> Result<()> {
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < timeout {
+        match is_in_state(project_path, id, expected_state) {
+            Ok(true) => return Ok(()),
+            Ok(false) => std::thread::sleep(poll_interval),
+            Err(e) => {
+                // If there's a transient error, continue polling
+                if e.to_string().contains("does not exist") && expected_state == "stopped" {
+                    // Special case: if container doesn't exist and we're waiting for stopped state,
+                    // consider it stopped (deletion after stopping)
+                    return Ok(());
+                }
+                std::thread::sleep(poll_interval);
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "Timed out waiting for container {} to reach {} state",
+        id,
+        expected_state
+    ))
 }

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod cgroups;
+pub mod delete;
 pub mod devices;
 pub mod domainname;
 pub mod example;


### PR DESCRIPTION
## Description

Added integration tests for the container delete operation to verify Youki's behavior in various container states. The tests check four scenarios:

1. Deleting a non-existent container (fails as expected)
2. Deleting a container in "created" state (succeeds as expected)
3. Deleting a container in "running" state (fails as expected)
4. Deleting a container in "stopped" state (succeeds as expected)

These tests improve our coverage of container lifecycle operations and ensure consistent behavior across Youki releases.

## Type of Change

<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (ran the new tests using the test framework)

## Related Issues

<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
#361

## Additional Context

The tests verify that Youki properly handles container deletion across different container states. Each test includes appropriate cleanup steps to ensure no resources are left behind after test execution.