### PR TITLE
update rust version to 1.85.0

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install cross-rs
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target
         run: |
           echo "CARGO=cross" >> ${GITHUB_ENV}
@@ -125,7 +125,7 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install cross-rs
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target
         run: |
           echo "CARGO=cross" >> ${GITHUB_ENV}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install cross-rs
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target
         run: |
           echo "CARGO=cross" >> ${GITHUB_ENV}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install cross-rs
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target
         run: |
           echo "CARGO=cross" >> ${GITHUB_ENV}

--- a/crates/libcgroups/src/v1/devices.rs
+++ b/crates/libcgroups/src/v1/devices.rs
@@ -158,7 +158,7 @@ mod tests {
         fn property_test_apply_multiple_devices(devices: Vec<LinuxDeviceCgroup>) -> bool {
             let tmp = tempfile::tempdir().unwrap();
             devices.iter()
-                .map(|device| {
+                .all(|device| {
                     set_fixture(tmp.path(), "devices.allow", "").expect("create allowed devices list");
                     set_fixture(tmp.path(), "devices.deny", "").expect("create denied devices list");
                     Devices::apply_device(device, tmp.path()).expect("Apply default device");
@@ -172,7 +172,6 @@ mod tests {
                         denied_content == device.to_string()
                     }
                 })
-                .all(|is_ok| is_ok)
         }
     }
 }

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -46,8 +46,8 @@ pub struct YoukiConfig {
     pub cgroup_path: PathBuf,
 }
 
-impl<'a> YoukiConfig {
-    pub fn from_spec(spec: &'a Spec, container_id: &str) -> Result<Self> {
+impl YoukiConfig {
+    pub fn from_spec(spec: &Spec, container_id: &str) -> Result<Self> {
         Ok(YoukiConfig {
             hooks: spec.hooks().clone(),
             cgroup_path: utils::get_cgroup_path(

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -28,16 +28,16 @@ pub enum ChannelError {
     OtherError(String),
 }
 
-/// Channel Design
-///
-/// Each of the main, intermediate, and init process will have a uni-directional
-/// channel, a sender and a receiver. Each process will hold the receiver and
-/// listen message on it. Each sender is shared between each process to send
-/// message to the corresponding receiver. For example, main_sender and
-/// main_receiver is used for the main process. The main process will use
-/// receiver to receive all message sent to the main process. The other
-/// processes will share the main_sender and use it to send message to the main
-/// process.
+// Channel Design
+//
+// Each of the main, intermediate, and init process will have a uni-directional
+// channel, a sender and a receiver. Each process will hold the receiver and
+// listen message on it. Each sender is shared between each process to send
+// message to the corresponding receiver. For example, main_sender and
+// main_receiver is used for the main process. The main process will use
+// receiver to receive all message sent to the main process. The other
+// processes will share the main_sender and use it to send message to the main
+// process.
 
 pub fn main_channel() -> Result<(MainSender, MainReceiver), ChannelError> {
     let (sender, receiver) = channel::<Message>()?;

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -795,41 +795,38 @@ fn set_supplementary_gids(
 
 /// set_io_priority set io priority
 fn set_io_priority(syscall: &dyn Syscall, io_priority_op: &Option<LinuxIOPriority>) -> Result<()> {
-    match io_priority_op {
-        Some(io_priority) => {
-            let io_prio_class_mapping: HashMap<_, _> = [
-                (IOPriorityClass::IoprioClassRt, 1i64),
-                (IOPriorityClass::IoprioClassBe, 2i64),
-                (IOPriorityClass::IoprioClassIdle, 3i64),
-            ]
-            .iter()
-            .filter_map(|(class, num)| match serde_json::to_string(&class) {
-                Ok(class_str) => Some((class_str, *num)),
-                Err(err) => {
-                    tracing::error!(?err, "failed to parse io priority class");
-                    None
-                }
-            })
-            .collect();
+    if let Some(io_priority) = io_priority_op {
+        let io_prio_class_mapping: HashMap<_, _> = [
+            (IOPriorityClass::IoprioClassRt, 1i64),
+            (IOPriorityClass::IoprioClassBe, 2i64),
+            (IOPriorityClass::IoprioClassIdle, 3i64),
+        ]
+        .iter()
+        .filter_map(|(class, num)| match serde_json::to_string(&class) {
+            Ok(class_str) => Some((class_str, *num)),
+            Err(err) => {
+                tracing::error!(?err, "failed to parse io priority class");
+                None
+            }
+        })
+        .collect();
 
-            let iop_class = serde_json::to_string(&io_priority.class())
-                .map_err(|err| InitProcessError::IoPriorityClass(err.to_string()))?;
+        let iop_class = serde_json::to_string(&io_priority.class())
+            .map_err(|err| InitProcessError::IoPriorityClass(err.to_string()))?;
 
-            match io_prio_class_mapping.get(&iop_class) {
-                Some(value) => {
-                    syscall
-                        .set_io_priority(*value, io_priority.priority())
-                        .map_err(|err| {
-                            tracing::error!(?err, ?io_priority, "failed to set io_priority");
-                            InitProcessError::SyscallOther(err)
-                        })?;
-                }
-                None => {
-                    return Err(InitProcessError::IoPriorityClass(iop_class));
-                }
+        match io_prio_class_mapping.get(&iop_class) {
+            Some(value) => {
+                syscall
+                    .set_io_priority(*value, io_priority.priority())
+                    .map_err(|err| {
+                        tracing::error!(?err, ?io_priority, "failed to set io_priority");
+                        InitProcessError::SyscallOther(err)
+                    })?;
+            }
+            None => {
+                return Err(InitProcessError::IoPriorityClass(iop_class));
             }
         }
-        None => {}
     }
     Ok(())
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile="default"
-channel="1.81.0"
+channel="1.85.0"

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -222,7 +222,12 @@ pub fn test_inside_container(
         .wait_with_output()
     {
         Ok(c) => c,
-        Err(e) => return TestResult::Failed(anyhow!("container start failed : {:?}", e)),
+        Err(e) => {
+            // given that start has failed, we can be pretty sure that create has either failed
+            // or completed already, so we wait on it so it does not become a zombie process
+            let _ = create_process.wait_with_output();
+            return TestResult::Failed(anyhow!("container start failed : {:?}", e));
+        }
     };
 
     let create_output = create_process


### PR DESCRIPTION
## Description
This updates rust version to latest stable 1.85.0. This also aligns with the new rust editions, and some deps like wasmtime require us to update our rust version to 1.82+ anyways.

The code changes are simply fixes suggested by clippy.

NOTE: it seems cross-rs has not yet caught up with latest rust version, so it is failing to compile. Will need to wait for them, or use pre-compiled binaries to avoid this.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [X] Other (please describe): Rust version update

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [X] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
N/A

## Additional Context
Even though  the fix suggestions by clippy should be correct, we should have another look for confirmation and sanity checks.
