### PR TITLE
fix: compilation errors in contest

### DIFF
--- a/tests/contest/contest/src/tests/linux_masked_paths/masked_paths.rs
+++ b/tests/contest/contest/src/tests/linux_masked_paths/masked_paths.rs
@@ -55,7 +55,7 @@ fn check_masked_paths() -> TestResult {
 
     let spec = get_spec(masked_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::fs;
         let test_dir = bundle_path.join(&masked_dir_sub);
         fs::create_dir_all(&test_dir)?;
@@ -87,7 +87,7 @@ fn check_masked_rel_paths() -> TestResult {
     let masked_paths = vec![masked_rel_path];
     let spec = get_spec(masked_paths);
 
-    let res = test_inside_container(spec, &CreateOptions::default(), &|_bundle_path| Ok(()));
+    let res = test_inside_container(&spec, &CreateOptions::default(), &|_bundle_path| Ok(()));
     // If the container creation succeeds, we expect an error since the masked paths does not support relative paths.
     if let TestResult::Passed = res {
         TestResult::Failed(anyhow!(
@@ -107,7 +107,7 @@ fn check_masked_symlinks() -> TestResult {
     let masked_paths = vec![root.join(MASKED_SYMLINK)];
     let spec = get_spec(masked_paths);
 
-    let res = test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    let res = test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::{fs, io};
         let test_file = bundle_path.join(MASKED_SYMLINK);
         // ln -s ../masked-symlink ; readlink -f /masked-symlink; ls -L /masked-symlink
@@ -162,7 +162,7 @@ fn test_mode(mode: u32) -> TestResult {
     let masked_paths = vec![root.join(MASKED_DEVICE)];
     let spec = get_spec(masked_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::os::unix::fs::OpenOptionsExt;
         use std::{fs, io};
         let test_file = bundle_path.join(MASKED_DEVICE);


### PR DESCRIPTION
## Description
When https://github.com/youki-dev/youki/pull/2950 was merged, it was not synced with main, hence the function types in that were differing. The CI on that PR was run before changes in main, hence it passed the checks, but failed when merged into main. This simply fixes those errors, not actual test changes.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->


## Additional Context
<!-- Add any other context about the pull request here -->
