### PR TITLE
fix(libcgroup): fix disable_oom_killer in cgroup v1

### DIFF
--- a/crates/libcgroups/src/v1/memory.rs
+++ b/crates/libcgroups/src/v1/memory.rs
@@ -204,10 +204,7 @@ impl Memory {
         Ok(memory_data)
     }
 
-    fn set_oom_control(
-        cgroup_root: &Path,
-        disable_oom_killer: bool,
-    ) -> Result<(), WrappedIoError> {
+    fn set_oom_control(cgroup_root: &Path, disable_oom_killer: bool) -> Result<(), WrappedIoError> {
         if disable_oom_killer {
             common::write_cgroup_file(cgroup_root.join(CGROUP_MEMORY_OOM_CONTROL), 1)
         } else {

--- a/crates/libcgroups/src/v1/memory.rs
+++ b/crates/libcgroups/src/v1/memory.rs
@@ -111,7 +111,7 @@ impl Controller for Memory {
                 )?;
             }
 
-            Self::set_disable_oom_killer(cgroup_root, controller_opt.disable_oom_killer)?;
+            Self::set_oom_control(cgroup_root, controller_opt.disable_oom_killer)?;
 
             if let Some(swappiness) = memory.swappiness() {
                 if swappiness <= 100 {
@@ -204,7 +204,7 @@ impl Memory {
         Ok(memory_data)
     }
 
-    fn set_disable_oom_killer(
+    fn set_oom_control(
         cgroup_root: &Path,
         disable_oom_killer: bool,
     ) -> Result<(), WrappedIoError> {
@@ -440,12 +440,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         set_fixture(tmp.path(), CGROUP_MEMORY_OOM_CONTROL, "0")
             .expect("Set fixure for oom control");
-        Memory::set_disable_oom_killer(tmp.path(), true).expect("Set oom control");
+        Memory::set_oom_control(tmp.path(), true).expect("Set oom control");
         let content = std::fs::read_to_string(tmp.path().join(CGROUP_MEMORY_OOM_CONTROL))
             .expect("Read to string");
         assert_eq!("1", content);
 
-        Memory::set_disable_oom_killer(tmp.path(), false).expect("Set oom control");
+        Memory::set_oom_control(tmp.path(), false).expect("Set oom control");
         let content = std::fs::read_to_string(tmp.path().join(CGROUP_MEMORY_OOM_CONTROL))
             .expect("Read to string");
         assert_eq!("0", content);

--- a/crates/libcgroups/src/v1/memory.rs
+++ b/crates/libcgroups/src/v1/memory.rs
@@ -111,11 +111,7 @@ impl Controller for Memory {
                 )?;
             }
 
-            if controller_opt.disable_oom_killer {
-                common::write_cgroup_file(cgroup_root.join(CGROUP_MEMORY_OOM_CONTROL), 0)?;
-            } else {
-                common::write_cgroup_file(cgroup_root.join(CGROUP_MEMORY_OOM_CONTROL), 1)?;
-            }
+            Self::set_disable_oom_killer(cgroup_root, controller_opt.disable_oom_killer)?;
 
             if let Some(swappiness) = memory.swappiness() {
                 if swappiness <= 100 {
@@ -206,6 +202,17 @@ impl Memory {
         };
 
         Ok(memory_data)
+    }
+
+    fn set_disable_oom_killer(
+        cgroup_root: &Path,
+        disable_oom_killer: bool,
+    ) -> Result<(), WrappedIoError> {
+        if disable_oom_killer {
+            common::write_cgroup_file(cgroup_root.join(CGROUP_MEMORY_OOM_CONTROL), 1)
+        } else {
+            common::write_cgroup_file(cgroup_root.join(CGROUP_MEMORY_OOM_CONTROL), 0)
+        }
     }
 
     fn hierarchy_enabled(cgroup_path: &Path) -> Result<bool, WrappedIoError> {
@@ -426,6 +433,22 @@ mod tests {
         let content =
             std::fs::read_to_string(tmp.path().join(CGROUP_MEMORY_LIMIT)).expect("Read to string");
         assert_eq!(limit.to_string(), content)
+    }
+
+    #[test]
+    fn test_disable_oom_kill() {
+        let tmp = tempfile::tempdir().unwrap();
+        set_fixture(tmp.path(), CGROUP_MEMORY_OOM_CONTROL, "0")
+            .expect("Set fixure for oom control");
+        Memory::set_disable_oom_killer(tmp.path(), true).expect("Set oom control");
+        let content = std::fs::read_to_string(tmp.path().join(CGROUP_MEMORY_OOM_CONTROL))
+            .expect("Read to string");
+        assert_eq!("1", content);
+
+        Memory::set_disable_oom_killer(tmp.path(), false).expect("Set oom control");
+        let content = std::fs::read_to_string(tmp.path().join(CGROUP_MEMORY_OOM_CONTROL))
+            .expect("Read to string");
+        assert_eq!("0", content);
     }
 
     #[test]

--- a/tests/contest/contest/src/tests/linux_masked_paths/masked_paths.rs
+++ b/tests/contest/contest/src/tests/linux_masked_paths/masked_paths.rs
@@ -55,7 +55,7 @@ fn check_masked_paths() -> TestResult {
 
     let spec = get_spec(masked_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::fs;
         let test_dir = bundle_path.join(&masked_dir_sub);
         fs::create_dir_all(&test_dir)?;
@@ -87,7 +87,7 @@ fn check_masked_rel_paths() -> TestResult {
     let masked_paths = vec![masked_rel_path];
     let spec = get_spec(masked_paths);
 
-    let res = test_inside_container(spec, &CreateOptions::default(), &|_bundle_path| Ok(()));
+    let res = test_inside_container(&spec, &CreateOptions::default(), &|_bundle_path| Ok(()));
     // If the container creation succeeds, we expect an error since the masked paths does not support relative paths.
     if let TestResult::Passed = res {
         TestResult::Failed(anyhow!(
@@ -107,7 +107,7 @@ fn check_masked_symlinks() -> TestResult {
     let masked_paths = vec![root.join(MASKED_SYMLINK)];
     let spec = get_spec(masked_paths);
 
-    let res = test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    let res = test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::{fs, io};
         let test_file = bundle_path.join(MASKED_SYMLINK);
         // ln -s ../masked-symlink ; readlink -f /masked-symlink; ls -L /masked-symlink
@@ -162,7 +162,7 @@ fn test_mode(mode: u32) -> TestResult {
     let masked_paths = vec![root.join(MASKED_DEVICE)];
     let spec = get_spec(masked_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::os::unix::fs::OpenOptionsExt;
         use std::{fs, io};
         let test_file = bundle_path.join(MASKED_DEVICE);


### PR DESCRIPTION
The intended behavior is to enable the OOM killer when disable_oom_killer is not set, which is the common case. However, since 0 means enable and 1 means disable, the if condition is currently reversed.

This is a really critical issue, as it will cause processes in the container to hang.

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
