### PR TITLE
fix: Gracefully terminate processes after successful execution of Wasm executors

### DIFF
--- a/crates/youki/src/workload/wasmer.rs
+++ b/crates/youki/src/workload/wasmer.rs
@@ -1,7 +1,9 @@
+use std::error::Error;
+
 use libcontainer::oci_spec::runtime::Spec;
 use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError, EMPTY};
 use wasmer::{Instance, Module, Store};
-use wasmer_wasix::WasiEnv;
+use wasmer_wasix::{WasiEnv, WasiError};
 
 const EXECUTOR_NAME: &str = "wasmer";
 
@@ -71,13 +73,21 @@ impl Executor for WasmerExecutor {
                 "could not retrieve wasm module main function: {err}"
             ))
         })?;
-        start
-            .call(&mut store, &[])
-            .map_err(|err| ExecutorError::Execution(err.into()))?;
+
+        start.call(&mut store, &[]).map_err(|err| {
+            if let Some(WasiError::Exit(exit_code)) = err
+                .source()
+                .and_then(|err_source| err_source.downcast_ref::<WasiError>())
+            {
+                std::process::exit(exit_code.raw())
+            } else {
+                ExecutorError::Execution(err.into())
+            }
+        })?;
 
         wasi_env.cleanup(&mut store, None);
 
-        Ok(())
+        std::process::exit(0)
     }
 
     fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError> {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
This PR ensures that processes are gracefully terminated after the successful execution of a Wasm executors.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes https://github.com/youki-dev/youki/issues/2917

## Additional Context
<!-- Add any other context about the pull request here -->
