### PR TITLE
chore(ci): add cgroup v1 compatibility for tests on ubuntu-24.04

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -184,14 +184,11 @@ jobs:
         run: just test-rootless-podman
   
   docker-in-docker:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     needs: [youki-build]
-    timeout-minutes: 5
     strategy:
       matrix:
-        # ubuntu 20.04 has cgroups-v1
-        # ubuntu 22.04 has cgroups-v2
-        os: [ "ubuntu-22.04", "ubuntu-20.04" ]
+        cgroup-version: ["v1", "v2"]
     steps:
       - uses: actions/checkout@v4
       - name: Install just
@@ -202,7 +199,53 @@ jobs:
           name: youki-x86_64-musl
       - name: Add the permission to run
         run: chmod +x ./youki
-      - name: Run tests
+      # Steps for cgroups-v1 only (using Lima with AlmaLinux 8)
+      - name: Setup Lima
+        if: matrix.cgroup-version == 'v1'
+        uses: lima-vm/lima-actions/setup@v1
+        id: lima-actions-setup
+      - uses: actions/cache@v4
+        if: matrix.cgroup-version == 'v1'
+        with:
+          path: ~/.cache/lima
+          key: lima-${{ steps.lima-actions-setup.outputs.version }}
+      - name: Start the guest VM
+        if: matrix.cgroup-version == 'v1'
+        run: |
+          set -eux
+          # containerd=none is set because the built-in containerd support conflicts with Docker
+          limactl start \
+            --name=default \
+            --cpus=4 \
+            --memory=8 \
+            --containerd=none \
+            --set '.mounts=[{"location":"~/","writable":true}] | .portForwards=[{"guestSocket":"/var/run/docker.sock","hostSocket":"{{.Dir}}/sock/docker.sock"}]' \
+            template://almalinux-8
+      - name: Install dockerd in the guest VM
+        if: matrix.cgroup-version == 'v1'
+        run: |
+          set -eux
+          lima sudo mkdir -p /etc/systemd/system/docker.socket.d
+          cat <<-EOF | lima sudo tee /etc/systemd/system/docker.socket.d/override.conf
+          [Socket]
+          SocketUser=$(whoami)
+          EOF
+          lima sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+          lima sudo dnf -q -y install docker-ce --nobest
+          lima sudo systemctl enable --now docker
+      - name: Configure the host to use dockerd in the guest VM
+        if: matrix.cgroup-version == 'v1'
+        run: |
+          set -eux
+          sudo systemctl disable --now docker.service docker.socket
+          export DOCKER_HOST="unix://$(limactl ls --format '{{.Dir}}/sock/docker.sock' default)"
+          echo "DOCKER_HOST=${DOCKER_HOST}" >>$GITHUB_ENV
+          docker info
+          docker version
+      # Run tests differently based on cgroup version
+      - name: Run tests (cgroups-v2)
+        if: matrix.cgroup-version == 'v2'
         run: just test-dind
-
-    
+      - name: Run tests (cgroups-v1)
+        if: matrix.cgroup-version == 'v1'
+        run: just test-dind


### PR DESCRIPTION
## Description
This PR adds support for testing with cgroups v1 on Ubuntu 24.04 by integrating Lima with AlmaLinux 8. AlmaLinux 8 provides an environment with cgroups v1 which allows us to maintain compatibility testing while upgrading the CI infrastructure to Ubuntu 24.04.

The implementation:
- Uses Lima to create a virtual machine with AlmaLinux 8 when running cgroups v1 tests
- Configures Docker in the guest VM and forwards the Docker socket to the host
- Maintains matrix testing for both cgroups v1 and v2 environments
- Keeps the workflow streamlined with conditional steps based on the cgroup version

This is a follow-up to PR #3097 which upgraded the GitHub Actions workflows to Ubuntu 24.04.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite in both cgroups v1 (Lima/AlmaLinux) and cgroups v2 (native) environments
- [x] Tested manually by running the workflow locally with Lima

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3095

## Additional Context
The approach was inspired by the containerd/nerdctl implementation ([4d76aa96b44df51e975171216d54879794b50605](https://github.com/containerd/nerdctl/commit/4d76aa96b44df51e975171216d54879794b50605)) which successfully uses Lima to provide cgroups v1 compatibility testing on modern Ubuntu versions.
