### PR TITLE
fix: CPU controller tests for Kernel 6.10 cgroup v2 changes

### DIFF
--- a/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
@@ -95,23 +95,25 @@ fn test_cpu_weight_zero_ignored() -> TestResult {
     })
 }
 
-/// Tests if a cpu weight that is too high (over 10000 after conversion) is set to the maximum value
+/// Tests behavior when setting a cpu weight that is too high
+/// According to kernel documentation, cpu.weight must be in range [1, 10000]
+/// Modern kernels enforce this range strictly and reject out-of-range values
 fn test_cpu_weight_too_high_maximum_set() -> TestResult {
     let cpu_weight = 500_000u64;
-    let converted_cpu_weight = 10_000;
     let cpu = test_result!(LinuxCpuBuilder::default()
         .shares(cpu_weight)
         .build()
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_weight_too_high_maximum_set", cpu));
-    test_outside_container(&spec, &|data| {
-        test_result!(check_container_created(&data));
-        test_result!(check_cpu_weight(
-            "test_cpu_weight_too_high_maximum_set",
-            converted_cpu_weight
-        ));
-        TestResult::Passed
+    // We accept both behaviors: either container creation fails due to
+    // out-of-range value, or it succeeds with weight set to maximum (10000)
+    test_outside_container(&spec, &|data| match check_container_created(&data) {
+        Ok(_) => match check_cpu_weight("test_cpu_weight_too_high_maximum_set", 10_000) {
+            Ok(_) => TestResult::Passed,
+            Err(e) => TestResult::Failed(anyhow::anyhow!("Weight check failed: {}", e)),
+        },
+        Err(_) => TestResult::Passed, // Failure is expected on kernels that strictly enforce range
     })
 }
 
@@ -179,6 +181,11 @@ fn test_cpu_quota_negative_default_set() -> TestResult {
 }
 
 /// Tests if a valid cpu period (x > 0) is set successfully
+/// According to kernel documentation, cpu.max format is "$MAX $PERIOD"
+/// Where $MAX can be "max" to indicate no limit
+/// If only one number is written, $MAX is updated (not $PERIOD)
+/// Therefore, to update only period while keeping quota unlimited,
+/// we must use format "max $PERIOD"
 fn test_cpu_period_valid_set() -> TestResult {
     let expected_period = 250_000;
     let cpu = test_result!(LinuxCpuBuilder::default()
@@ -187,6 +194,7 @@ fn test_cpu_period_valid_set() -> TestResult {
         .context("build cpu spec"));
 
     let spec = test_result!(create_spec("test_cpu_period_valid_set", cpu));
+    // Set period with "max $PERIOD" format as required by kernel docs
     test_result!(prepare_cpu_max(&spec, "max", &expected_period.to_string()));
 
     test_outside_container(&spec, &|data| {
@@ -196,15 +204,18 @@ fn test_cpu_period_valid_set() -> TestResult {
         if parts.len() != 2 {
             return TestResult::Failed(anyhow::anyhow!("Invalid cpu.max format: {}", data));
         }
+        let quota = parts[0].trim();
         let period = parts[1].trim();
+        // Verify period is set correctly
         let actual_period = match period.parse::<u64>() {
             Ok(p) => p,
             Err(e) => return TestResult::Failed(anyhow::anyhow!("Failed to parse period: {}", e)),
         };
-        if actual_period != expected_period {
+        if actual_period != expected_period || quota != "max" {
             return TestResult::Failed(anyhow::anyhow!(
-                "expected cpu period to be {}, but was {}",
+                "expected cpu.max to be 'max {}', but was '{} {}'",
                 expected_period,
+                quota,
                 actual_period
             ));
         }


### PR DESCRIPTION
## Description
Fix CPU controller tests to work with Ubuntu 24.04's cgroup v2 implementation, which now more strictly follows the Linux kernel documentation.

Ubuntu 24.04 has changed the behavior of cgroup v2 CPU controller in two significant ways:
1. `cpu.max` format is now strictly enforced as "$MAX $PERIOD" as per kernel docs. When updating only period, you must use "max $PERIOD" format (previously "- $PERIOD" worked)
2. `cpu.weight` range [1, 10000] is now strictly enforced, rejecting out-of-range values with "Numerical result out of range" rather than silently capping them to the maximum

These changes align with the kernel documentation, which states:
- For `cpu.max`: "The maximum bandwidth limit. It's in the following format: $MAX $PERIOD... If only one number is written, $MAX is updated." 
- For `cpu.weight`: "For non idle groups (cpu.idle = 0), the weight is in the range [1, 10000]."

This PR modifies the tests to be compatible with both the historic behavior and the new strict enforcement in Ubuntu 24.04.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)
  - Tested on Ubuntu 24.04 with cgroup v2 enabled
  - Confirmed that tests now pass on both Ubuntu 24.04 and older systems

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
fixed #3104
Related to opencontainers/runc#4166 (similar cgroup v2 behavior changes)

## Additional Context
A recent kernel patch (https://lore.kernel.org/all/20240424132438.514720-1-serein.chengyu@huawei.com/) related to cgroup v2 CPU controller parameter handling has been merged into Linux Kernel 6.10. This confirms that these behavioral changes are now official part of the mainline kernel.

Ubuntu 24.04 appears to have backported these or similar changes to their kernel (likely 6.8+), resulting in the stricter enforcement of the cgroup v2 documentation specifications.

In the future, we could consider adding kernel version detection to make tests more deterministic (e.g., expecting strict behavior for kernel 6.10+ and the legacy behavior for older versions), but the current approach ensures compatibility across all kernel versions by accepting both behaviors.

This is similar to the issue found in opencontainers/runc where newer kernel implementations of cgroup v2 have subtle behavioral differences from older versions. The fix makes the tests more flexible to accommodate these differences while still validating the core functionality.

This is follow-up PR #3097