### PR TITLE
Add GitHub Actions to Dependabot configuration and pin actions to specific SHAs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,8 +14,9 @@ EOF
 
 RUN <<EOF
 apt-get update
+
+# For building
 apt-get install -y \
-  # For building
   build-essential \
   git \
   libclang-dev \
@@ -23,10 +24,12 @@ apt-get install -y \
   libseccomp-dev \
   libssl-dev \
   libsystemd-dev \
-  pkg-config \
-  # For debugging
-  bpftrace \
-  podman
+  pkg-config
+
+# For debugging
+apt-get install -y \
+  podman \
+  bpftrace
 
 curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
       patch:
         update-types: 
         - patch
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -17,18 +17,56 @@ jobs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@v41
-        id: filter
         with:
-          files_ignore: |
-            docs
-            LICENSE
-            **.md
+          fetch-depth: 0  # Required to get full history
+      # Using Git commands instead of tj-actions/changed-files
+      - name: Get changed files
+        id: filter
+        run: |
+          # Change the base commit depending on event type
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            # For push events
+            if [[ -n "${{ github.event.before }}" ]]; then
+              BASE_COMMIT="${{ github.event.before }}"
+            else
+              # For workflow dispatch, etc.
+              git fetch origin main --depth=1
+              BASE_COMMIT="origin/main"
+            fi
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # For pull request events
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            BASE_COMMIT="origin/${{ github.base_ref }}"
+          else
+            # For workflow dispatch events
+            git fetch origin main --depth=1
+            BASE_COMMIT="HEAD~1"
+          fi
+          
+          echo "Using base commit: $BASE_COMMIT"
+          
+          # Get changed files and filter out the ones to ignore
+          ALL_CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "$BASE_COMMIT" HEAD)
+          FILTERED_FILES=$(echo "$ALL_CHANGED_FILES" | grep -v -E '^docs/|^LICENSE$|\.md$')
+          
+          # Set the results
+          if [[ -n "$FILTERED_FILES" ]]; then
+            echo "any_modified=true" >> $GITHUB_OUTPUT
+            echo "all_modified_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILTERED_FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "any_modified=false" >> $GITHUB_OUTPUT
+            echo "all_modified_files=" >> $GITHUB_OUTPUT
+          fi
       - name: List all changed files
         run: |
-          for file in ${{ steps.filter.outputs.all_modified_files }}; do
-            echo "$file was changed"
-          done
+          if [[ "${{ steps.filter.outputs.any_modified }}" == "true" ]]; then
+            echo "Changed files detected:"
+            echo "${{ steps.filter.outputs.all_modified_files }}"
+          else
+            echo "No relevant changes detected"
+          fi
 
   check:
     needs: [changes]

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Required to get full history
       # Using Git commands instead of tj-actions/changed-files
@@ -78,17 +78,19 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
         with:
           components: clippy
       - name: Install nightly rustfmt
         run: rustup toolchain install nightly --component rustfmt --profile minimal --no-self-update
       - name: typos-action
-        uses: crate-ci/typos@v1.22.9
+        uses: crate-ci/typos@c16dc8f5b4a7ad6211464ecf136c69c851e8e83c # v1.22.9
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Install cross-rs
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target
@@ -98,7 +100,7 @@ jobs:
       - name: Check formatting and lints
         run: just lint
       - name: Install cargo machete
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
         with:
           tool: cargo-machete@0.7.0
       - name: Check unused deps
@@ -114,11 +116,13 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Install cross-rs
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
@@ -33,7 +33,7 @@ jobs:
   check:
     needs: [changes]
     if: needs.changes.outputs.any_modified == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -69,7 +69,7 @@ jobs:
   tests:
     needs: [changes]
     if: needs.changes.outputs.any_modified == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       matrix:
@@ -87,6 +87,8 @@ jobs:
         run: |
           echo "CARGO=cross" >> ${GITHUB_ENV}
           echo "TARGET=${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}" >> ${GITHUB_ENV}
+      - name: Disable AppArmor restrictions
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Run tests
         run: just test-basic
       - name: Run feature tests
@@ -98,7 +100,7 @@ jobs:
   # coverage:
   #   needs: [changes]
   #   if: needs.changes.outputs.any_modified == 'true'
-  #   runs-on: ubuntu-22.04
+  #   runs-on: ubuntu-24.04
   #   timeout-minutes: 20
   #   name: Run test coverage
   #   steps:

--- a/.github/workflows/benchmark_execution_time.yml
+++ b/.github/workflows/benchmark_execution_time.yml
@@ -12,22 +12,24 @@ jobs:
 
     steps:
       - name: Checkout to PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install requirements
         run: sudo ./.github/scripts/dependency.sh
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+        uses: actions-rust-lang/setup-rust-toolchain@dfa8744db3c65831067d3386253fc8ec50fd8cfd # v1.3.7
 
       - name: Install Just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
 
       - name: Building PR branch
         run: just youki-release
 
       - name: Uploading PR build to artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: pr-youki
           path: ./youki
@@ -39,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout to main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
 
@@ -47,15 +49,17 @@ jobs:
         run: sudo ./.github/scripts/dependency.sh
 
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+        uses: actions-rust-lang/setup-rust-toolchain@dfa8744db3c65831067d3386253fc8ec50fd8cfd # v1.3.7
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
 
       - name: Building main branch
         run: just youki-release
 
       - name: Uploading main build to artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: main-youki
           path: ./youki
@@ -75,16 +79,16 @@ jobs:
           sudo apt install jq podman
 
       - name: Checkout to PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Downloading PR build from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: pr-youki
           path: ./pr_youki
 
       - name: Downloading main build from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: main-youki
           path: ./main_youki

--- a/.github/workflows/benchmark_execution_time.yml
+++ b/.github/workflows/benchmark_execution_time.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   building-pr-branch:
     if: (github.event.issue.pull_request != null) && github.event.comment.body == '!github easy-benchmark'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:
@@ -34,7 +34,7 @@ jobs:
 
   building-main-branch:
     if: (github.event.issue.pull_request != null) && github.event.comment.body == '!github easy-benchmark'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:
@@ -65,7 +65,7 @@ jobs:
     needs:
       - building-pr-branch
       - building-main-branch
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/dependabot_auto.yaml
+++ b/.github/workflows/dependabot_auto.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.5
+        uses: dependabot/fetch-metadata@5ef00187930bafb52d529e0b9c3dff045dfa9851 # v1.3.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Approve & enable auto-merge for Dependabot PR
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Automerge
         id: automerge
-        uses: pascalgn/automerge-action@v0.15.6
+        uses: pascalgn/automerge-action@22948e0bc22f0aa673800da838595a3e7347e584 # v0.15.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: dependencies

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,8 +12,8 @@ jobs:
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: filter
         with:
           filters: |
@@ -26,16 +26,16 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
+        uses: peaceiris/actions-mdbook@adeb05db28a0c0004681db83893d56c0388ea9ea # v1.2.0
         with:
           mdbook-version: "latest"
       - name: Build mdbook
         working-directory: ./docs
         run: mdbook build
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
@@ -21,7 +21,7 @@ jobs:
   deploy:
     needs: [changes]
     if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,13 +17,15 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+        uses: actions-rust-lang/setup-rust-toolchain@dfa8744db3c65831067d3386253fc8ec50fd8cfd # v1.3.7
         env:
           RUST_CACHE_KEY_OS: rust-cache-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Install cross-rs
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target
@@ -34,7 +36,7 @@ jobs:
         run: just youki-release
       - name: Upload youki binary
         if: ${{ matrix.arch == 'x86_64' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
           path: youki
@@ -48,11 +50,11 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: containerd/containerd
           ref: v1.7.11
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '1.20.12'
           cache: true
@@ -66,7 +68,7 @@ jobs:
           ./script/setup/install-cni
           ./script/setup/install-critools
       - name: Download youki binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Replace runc to youki
@@ -87,15 +89,17 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Download youki binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
         run: chmod +x ./youki
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: test/k8s/deploy
         run: just test-kind
 
@@ -108,20 +112,22 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
       - name: Install just
-        uses: taiki-e/install-action@just
-      - uses: actions/setup-go@v5
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '1.20'
           cache: true
           cache-dependency-path: tests/oci-runtime-tests/src/github.com/opencontainers/runtime-tools/go.sum
       - name: Download youki binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
@@ -138,19 +144,21 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Add CRIU PPA
         run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       - name: Download youki binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
@@ -167,19 +175,21 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Add CRIU PPA
         run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       - name: Download youki binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
@@ -194,11 +204,13 @@ jobs:
       matrix:
         cgroup-version: ["v1", "v2"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Download youki binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: youki-x86_64-musl
       - name: Add the permission to run
@@ -206,9 +218,9 @@ jobs:
       # Steps for cgroups-v1 only (using Lima with AlmaLinux 8)
       - name: Setup Lima
         if: matrix.cgroup-version == 'v1'
-        uses: lima-vm/lima-actions/setup@v1
+        uses: lima-vm/lima-actions/setup@be564a1408f84557d067b099a475652288074b2e # v1.0.0
         id: lima-actions-setup
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         if: matrix.cgroup-version == 'v1'
         with:
           path: ~/.cache/lima

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -184,14 +184,11 @@ jobs:
         run: just test-rootless-podman
   
   docker-in-docker:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     needs: [youki-build]
-    timeout-minutes: 5
     strategy:
       matrix:
-        # ubuntu 20.04 has cgroups-v1
-        # ubuntu 22.04 has cgroups-v2
-        os: [ "ubuntu-22.04", "ubuntu-20.04" ]
+        cgroup-version: ["v1", "v2"]
     steps:
       - uses: actions/checkout@v4
       - name: Install just
@@ -202,7 +199,53 @@ jobs:
           name: youki-x86_64-musl
       - name: Add the permission to run
         run: chmod +x ./youki
-      - name: Run tests
+      # Steps for cgroups-v1 only (using Lima with AlmaLinux 8)
+      - name: Setup Lima
+        if: matrix.cgroup-version == 'v1'
+        uses: lima-vm/lima-actions/setup@v1
+        id: lima-actions-setup
+      - uses: actions/cache@v4
+        if: matrix.cgroup-version == 'v1'
+        with:
+          path: ~/.cache/lima
+          key: lima-${{ steps.lima-actions-setup.outputs.version }}
+      - name: Start the guest VM
+        if: matrix.cgroup-version == 'v1'
+        run: |
+          set -eux
+          # containerd=none is set because the built-in containerd support conflicts with Docker
+          limactl start \
+            --name=default \
+            --cpus=4 \
+            --memory=8 \
+            --containerd=none \
+            --set '.mounts=[{"location":"~/","writable":true}] | .portForwards=[{"guestSocket":"/var/run/docker.sock","hostSocket":"{{.Dir}}/sock/docker.sock"}]' \
+            template://almalinux-8
+      - name: Install dockerd in the guest VM
+        if: matrix.cgroup-version == 'v1'
+        run: |
+          set -eux
+          lima sudo mkdir -p /etc/systemd/system/docker.socket.d
+          cat <<-EOF | lima sudo tee /etc/systemd/system/docker.socket.d/override.conf
+          [Socket]
+          SocketUser=$(whoami)
+          EOF
+          lima sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+          lima sudo dnf -q -y install docker-ce --nobest
+          lima sudo systemctl enable --now docker
+      - name: Configure the host to use dockerd in the guest VM
+        if: matrix.cgroup-version == 'v1'
+        run: |
+          set -eux
+          sudo systemctl disable --now docker.service docker.socket
+          export DOCKER_HOST="unix://$(limactl ls --format '{{.Dir}}/sock/docker.sock' default)"
+          echo "DOCKER_HOST=${DOCKER_HOST}" >>$GITHUB_ENV
+          docker info
+          docker version
+      # Run tests differently based on cgroup version
+      - name: Run tests (cgroups-v2)
+        if: matrix.cgroup-version == 'v2'
         run: just test-dind
-
-    
+      - name: Run tests (cgroups-v1)
+        if: matrix.cgroup-version == 'v1'
+        run: just test-dind

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   youki-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -40,7 +40,7 @@ jobs:
           path: youki
 
   containerd-integration-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [youki-build]
     timeout-minutes: 40
     strategy:
@@ -79,7 +79,7 @@ jobs:
         run: sudo make RUNC_FLAVOR=crun TEST_RUNTIME=io.containerd.runc.v2 TESTFLAGS="-timeout 40m" integration
 
   k8s-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [youki-build]
     timeout-minutes: 40
     strategy:
@@ -100,7 +100,7 @@ jobs:
         run: just test-kind
 
   oci-validation-go:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [youki-build]
     timeout-minutes: 15
     strategy:
@@ -130,7 +130,7 @@ jobs:
         run: just test-oci
 
   oci-validation-rust:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [youki-build]
     timeout-minutes: 20
     strategy:
@@ -145,6 +145,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
         uses: taiki-e/install-action@just
+      - name: Add CRIU PPA
+        run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       - name: Download youki binary
@@ -157,7 +159,7 @@ jobs:
         run: just test-contest
 
   rootless-podman-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [youki-build]
     timeout-minutes: 20
     strategy:
@@ -172,6 +174,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
         uses: taiki-e/install-action@just
+      - name: Add CRIU PPA
+        run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       - name: Download youki binary

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Required to get full history
       # Using Git commands instead of tj-actions/changed-files
@@ -79,11 +79,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+        uses: actions-rust-lang/setup-rust-toolchain@dfa8744db3c65831067d3386253fc8ec50fd8cfd # v1.3.7
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Add CRIU PPA
         run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -17,19 +17,62 @@ jobs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@v41
-        id: filter
         with:
-          files: |
-            .github/workflows/integration_tests_validation.yaml
-            tests/contest/**
-          files_ignore: |
-            **.md
+          fetch-depth: 0  # Required to get full history
+      # Using Git commands instead of tj-actions/changed-files
+      - name: Get changed files
+        id: filter
+        run: |
+          # Change the base commit depending on event type
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            # For push events
+            if [[ -n "${{ github.event.before }}" ]]; then
+              BASE_COMMIT="${{ github.event.before }}"
+            else
+              # For workflow dispatch, etc.
+              git fetch origin main --depth=1
+              BASE_COMMIT="origin/main"
+            fi
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # For pull request events
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            BASE_COMMIT="origin/${{ github.base_ref }}"
+          else
+            # For workflow dispatch events
+            git fetch origin main --depth=1
+            BASE_COMMIT="HEAD~1"
+          fi
+          
+          echo "Using base commit: $BASE_COMMIT"
+          
+          # Get all changed files
+          ALL_CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "$BASE_COMMIT" HEAD)
+          
+          # Filter only files matching the specified patterns
+          # Match files in .github/workflows/integration_tests_validation.yaml and tests/contest/**
+          TARGET_FILES=$(echo "$ALL_CHANGED_FILES" | grep -E '^.github/workflows/integration_tests_validation.yaml$|^tests/contest/')
+          
+          # Exclude markdown files
+          FILTERED_FILES=$(echo "$TARGET_FILES" | grep -v '\.md$')
+          
+          # Set the results
+          if [[ -n "$FILTERED_FILES" ]]; then
+            echo "any_modified=true" >> $GITHUB_OUTPUT
+            echo "all_modified_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$FILTERED_FILES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "any_modified=false" >> $GITHUB_OUTPUT
+            echo "all_modified_files=" >> $GITHUB_OUTPUT
+          fi
       - name: List all changed files
         run: |
-          for file in ${{ steps.filter.outputs.all_modified_files }}; do
-            echo "$file was changed"
-          done
+          if [[ "${{ steps.filter.outputs.any_modified }}" == "true" ]]; then
+            echo "Changed files detected:"
+            echo "${{ steps.filter.outputs.all_modified_files }}"
+          else
+            echo "No relevant changes detected"
+          fi
   validate:
     needs: [changes]
     if: needs.changes.outputs.any_modified == 'true'

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
@@ -33,7 +33,7 @@ jobs:
   validate:
     needs: [changes]
     if: needs.changes.outputs.any_modified == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +41,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install just
         uses: taiki-e/install-action@just
+      - name: Add CRIU PPA
+        run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       - name: Install runc 1.1.11

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -9,9 +9,11 @@ jobs:
   podman-tests:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       
@@ -26,7 +28,7 @@ jobs:
           sudo cp $(which netavark) /usr/local/lib/podman && sudo cp $(which netavark)-dhcp-proxy-client /usr/local/lib/podman && sudo cp $(which aardvark-dns) /usr/local/lib/podman
       
       # setup go
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '1.22'
           cache: false
@@ -48,7 +50,7 @@ jobs:
 
       # build podman
       - name: Clone podman repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: containers/podman
       - name: Build podman

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   podman-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install just

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
     name: Publish Packages
     needs: release
     runs-on: ubuntu-22.04
-    if: ${{ github.repository == 'containers/youki' }}
+    if: ${{ github.repository == 'youki-dev/youki' }}
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
         - parse
     strategy:
@@ -62,7 +62,7 @@ jobs:
     name: Create Draft Release
     environment:
       name: release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     needs:
@@ -91,7 +91,7 @@ jobs:
   publish:
     name: Publish Packages
     needs: release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'youki-dev/youki' }}
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,15 +26,17 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
         env:
           RUST_CACHE_KEY_OS: rust-cache-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
       - name: Install cross-rs
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup target
@@ -53,7 +55,7 @@ jobs:
       - name: Create artifact
         run: tar -zcvf youki-${{ needs.parse.outputs.version }}-${{ matrix.arch }}-${{ matrix.libc }}.tar.gz youki README.md LICENSE
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
           path: youki-${{ needs.parse.outputs.version }}-${{ matrix.arch }}-${{ matrix.libc }}.tar.gz
@@ -69,11 +71,11 @@ jobs:
       - parse
       - build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create artifacts directory
         run: mkdir -p artifacts
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           path: artifacts
       - name: Show artifacts
@@ -96,9 +98,9 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1.11.0
       - name: Publish libcgroups
         run: cargo publish -p libcgroups --no-verify
       - name: Publish libcontainer

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -7,17 +7,19 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install just
-        uses: taiki-e/install-action@just
-      - uses: Songmu/tagpr@v1
+        uses: taiki-e/install-action@62730e3d4f6bd81d824694e963e06d7153968c93 # v2.49.29
+        with:
+          tool: just
+      - uses: Songmu/tagpr@e89d37247ca73d3e5620bf074a53fbd5b39e66b0 # v1.5.1
         id: tagpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Trigger Release Workflow(only when tagged)
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         if: "steps.tagpr.outputs.tag != ''"
         with:
           script: |

--- a/.github/workflows/update_version_config.yaml
+++ b/.github/workflows/update_version_config.yaml
@@ -8,7 +8,7 @@ on:
         required: true
 jobs:
   config:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/update_version_config.yaml
+++ b/.github/workflows/update_version_config.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Update tagpr config
@@ -25,7 +25,7 @@ jobs:
               release = false
               changelog = true
           EOF
-      - uses: peter-evans/create-pull-request@v5
+      - uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
           title: 'config: Automated Tagpr Update for ${{ github.event.inputs.version }}'
           add-paths: |

--- a/.tagpr
+++ b/.tagpr
@@ -2,6 +2,6 @@
     vPrefix = true
     releaseBranch = main
     versionFile = -
-    command = just version-up 0.5.2
+    command = just version-up 0.5.3
     release = false
     changelog = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v0.5.2](https://github.com/youki-dev/youki/compare/v0.5.1...v0.5.2) - 2025-03-04
+### 💪 Improvements
+- Support feature subcommand by @musaprg in https://github.com/youki-dev/youki/pull/2837
+### 🐛 Bug Fixes
+- fix(libcgroup): fix disable_oom_killer in cgroup v1 by @xujihui1985 in https://github.com/youki-dev/youki/pull/3090
+### 🧪 Test improvements and Misc Fixes
+- Add a PR template file by @Gekko0114 in https://github.com/youki-dev/youki/pull/3049
+- add process rlimits fail test by @ntkm61027 in https://github.com/youki-dev/youki/pull/3051
+- Use MountOption enum to parse mount options defined in the spec by @musaprg in https://github.com/youki-dev/youki/pull/2937
+- ci: Publish packages after the release flow by @utam0k in https://github.com/youki-dev/youki/pull/3064
+- Make `sepc` into `&spec` in test_{outside,inside}_containe by @utam0k in https://github.com/youki-dev/youki/pull/3068
+- linux_masked_paths integration test by @nayuta-ai in https://github.com/youki-dev/youki/pull/2950
+- fix: compilation errors in contest by @YJDoc2 in https://github.com/youki-dev/youki/pull/3086
+- Remove problematic comments between package name in apt install by @musaprg in https://github.com/youki-dev/youki/pull/3060
+- Add `delete` test by @sou1118 in https://github.com/youki-dev/youki/pull/3082
+### Other Changes
+- Upgrade direct dep rand to 0.9.0 by @YJDoc2 in https://github.com/youki-dev/youki/pull/3083
+- rollup multiple dep updates by @YJDoc2 in https://github.com/youki-dev/youki/pull/3084
+- lset_file_label should check for symlink instead of raw file by @foreverddong in https://github.com/youki-dev/youki/pull/3073
+
 ## [v0.5.1](https://github.com/youki-dev/youki/compare/v0.5.0...v0.5.1) - 2025-01-06
 ### 🐛 Bug Fixes
 - Fix building the wasmedge feature by @utam0k in https://github.com/youki-dev/youki/pull/3041

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,11 +4034,10 @@ checksum = "dc12939a1c9b9d391e0b7135f72fd30508b73450753e28341fed159317582a77"
 
 [[package]]
 name = "tempfile"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
+checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,7 +2006,7 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libcgroups"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "libcontainer"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "caps",
@@ -2078,7 +2078,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "liboci-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
 ]
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "youki"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "caps",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 0.38.40",
  "windows-sys 0.52.0",
  "winx",
 ]
@@ -392,7 +392,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix",
+ "rustix 0.38.40",
 ]
 
 [[package]]
@@ -405,7 +405,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix",
+ "rustix 0.38.40",
  "winx",
 ]
 
@@ -1298,7 +1298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.40",
  "windows-sys 0.52.0",
 ]
 
@@ -1310,7 +1310,7 @@ checksum = "03d7057d9db6e5266b609656724393781a1d75beb1159134420e0a47a7d1fae6"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix",
+ "rustix 0.38.40",
  "wasmtime-asm-macros 14.0.4",
  "wasmtime-versioned-export-macros 14.0.4",
  "windows-sys 0.48.0",
@@ -1399,7 +1399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033b337d725b97690d86893f9de22b67b80dcc4e9ad815f348254c38119db8fb"
 dependencies = [
  "io-lifetimes",
- "rustix",
+ "rustix 0.38.40",
  "windows-sys 0.52.0",
 ]
 
@@ -2133,6 +2133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,7 +2199,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix",
+ "rustix 0.38.40",
 ]
 
 [[package]]
@@ -2853,7 +2859,7 @@ dependencies = [
  "flate2",
  "hex",
  "procfs-core",
- "rustix",
+ "rustix 0.38.40",
 ]
 
 [[package]]
@@ -3365,9 +3371,22 @@ dependencies = [
  "errno",
  "itoa",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "once_cell",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3971,7 +3990,7 @@ dependencies = [
  "cap-std",
  "fd-lock",
  "io-lifetimes",
- "rustix",
+ "rustix 0.38.40",
  "windows-sys 0.52.0",
  "winx",
 ]
@@ -4016,15 +4035,15 @@ checksum = "dc12939a1c9b9d391e0b7135f72fd30508b73450753e28341fed159317582a77"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.0",
  "windows-sys 0.59.0",
 ]
 
@@ -4790,7 +4809,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes",
  "log",
- "rustix",
+ "rustix 0.38.40",
  "system-interface",
  "thiserror 1.0.69",
  "tracing",
@@ -5278,7 +5297,7 @@ dependencies = [
  "psm",
  "pulley-interpreter",
  "rayon",
- "rustix",
+ "rustix 0.38.40",
  "semver 1.0.22",
  "serde",
  "serde_derive",
@@ -5335,7 +5354,7 @@ dependencies = [
  "directories-next",
  "log",
  "postcard",
- "rustix",
+ "rustix 0.38.40",
  "serde",
  "serde_derive",
  "sha2",
@@ -5426,7 +5445,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "rustix",
+ "rustix 0.38.40",
  "wasmtime-asm-macros 29.0.1",
  "wasmtime-versioned-export-macros 29.0.1",
  "windows-sys 0.59.0",
@@ -5439,7 +5458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e7b61488a5ee00c35c8c22de707c36c0aecacf419a3be803a6a2ba5e860f56a"
 dependencies = [
  "object 0.36.7",
- "rustix",
+ "rustix 0.38.40",
  "wasmtime-versioned-export-macros 29.0.1",
 ]
 
@@ -5615,7 +5634,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.40",
 ]
 
 [[package]]
@@ -5626,7 +5645,7 @@ checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 0.38.40",
  "winsafe",
 ]
 
@@ -6026,8 +6045,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "linux-raw-sys 0.4.14",
+ "rustix 0.38.40",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arbitrary"
@@ -2025,7 +2025,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2056,7 +2056,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2484,7 +2484,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3573,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -4081,11 +4081,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4101,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,9 +4530,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "openssl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3550,9 +3550,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -3580,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,15 +459,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2067,7 +2067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5729,6 +5729,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libcgroups"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openssl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -2067,7 +2067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3259,15 +3259,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.13",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcgroups"
-version = "0.5.1" # MARK: Version
+version = "0.5.2" # MARK: Version
 description = "Library for cgroup"
 license = "Apache-2.0"
 repository = "https://github.com/containers/youki"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -29,7 +29,7 @@ rbpf = { version = "0.3.0", optional = true }
 libbpf-sys = { version = "1.5.0", optional = true }
 errno = { version = "0.3.10", optional = true }
 libc = { version = "0.2.170", optional = true }
-thiserror = "2.0.11"
+thiserror = "2.0.12"
 tracing = { version = "0.1.41", features = ["attributes"] }
 
 [dev-dependencies]

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 rbpf = { version = "0.3.0", optional = true }
 libbpf-sys = { version = "1.5.0", optional = true }
 errno = { version = "0.3.10", optional = true }
-libc = { version = "0.2.170", optional = true }
+libc = { version = "0.2.171", optional = true }
 thiserror = "2.0.12"
 tracing = { version = "0.1.41", features = ["attributes"] }
 

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcontainer"
-version = "0.5.1" # MARK: Version
+version = "0.5.2" # MARK: Version
 description = "Library for container control"
 license = "Apache-2.0"
 repository = "https://github.com/containers/youki"
@@ -41,7 +41,7 @@ oci-spec = { version = "0.7.1", features = ["runtime"] }
 once_cell = "1.20.3"
 procfs = "0.17.0"
 prctl = "1.0.0"
-libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.1" } # MARK: Version
+libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.2" } # MARK: Version
 libseccomp = { version = "0.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { version = "0.4", default-features = false, features = [
     "serde",
 ] }
 fastrand = "^2.3.0"
-libc = "0.2.170"
+libc = "0.2.171"
 nix = { version = "0.28.0", features = [
     "socket",
     "sched",

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -38,7 +38,7 @@ nix = { version = "0.28.0", features = [
     "hostname",
 ] }
 oci-spec = { version = "0.7.1", features = ["runtime"] }
-once_cell = "1.21.0"
+once_cell = "1.21.1"
 procfs = "0.17.0"
 prctl = "1.0.0"
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.2" } # MARK: Version

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -38,7 +38,7 @@ nix = { version = "0.28.0", features = [
     "hostname",
 ] }
 oci-spec = { version = "0.7.1", features = ["runtime"] }
-once_cell = "1.20.3"
+once_cell = "1.21.0"
 procfs = "0.17.0"
 prctl = "1.0.0"
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.2" } # MARK: Version

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-criu = "0.4.0"
 regex = { version = "1.10.6", default-features = false, features = ["std", "unicode-perl"] }
-thiserror = "2.0.11"
+thiserror = "2.0.12"
 tracing = { version = "0.1.41", features = ["attributes"] }
 safe-path = "0.1.0"
 nc = "0.9.5"

--- a/crates/liboci-cli/Cargo.toml
+++ b/crates/liboci-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liboci-cli"
-version = "0.5.1" # MARK: Version
+version = "0.5.2" # MARK: Version
 description = "Parse command line arguments for OCI container runtimes"
 license = "Apache-2.0"
 repository = "https://github.com/containers/youki"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youki"
-version = "0.5.1" # MARK: Version
+version = "0.5.2" # MARK: Version
 description = "A container runtime written in Rust"
 license = "Apache-2.0"
 repository = "https://github.com/containers/youki"
@@ -30,9 +30,9 @@ features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-con
 [dependencies]
 anyhow = "1.0.97"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
-libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.1" } # MARK: Version
-libcontainer = { path = "../libcontainer", default-features = false, version = "0.5.1" } # MARK: Version
-liboci-cli = { path = "../liboci-cli", version = "0.5.1" } # MARK: Version
+libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.2" } # MARK: Version
+libcontainer = { path = "../libcontainer", default-features = false, version = "0.5.2" } # MARK: Version
+liboci-cli = { path = "../liboci-cli", version = "0.5.2" } # MARK: Version
 nix = "0.28.0"
 pentacle = "1.1.0"
 procfs = "0.17.0"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -28,7 +28,7 @@ default-features = false
 features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-context"]
 
 [dependencies]
-anyhow = "1.0.96"
+anyhow = "1.0.97"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.1" } # MARK: Version
 libcontainer = { path = "../libcontainer", default-features = false, version = "0.5.1" } # MARK: Version
@@ -55,5 +55,5 @@ tempfile = "3"
 scopeguard = "1.2.0"
 
 [build-dependencies]
-anyhow = "1.0.96"
+anyhow = "1.0.97"
 vergen-gitcl = { version = "1.0.5", features = ["build"] }

--- a/docs/src/user/basic_setup.md
+++ b/docs/src/user/basic_setup.md
@@ -83,7 +83,7 @@ Install from the GitHub release as root:
 
 <!--youki release begin-->
 ```console
-# curl -sSfL https://github.com/containers/youki/releases/download/v0.5.1/youki-0.5.1-$(uname -m)-musl.tar.gz | tar -xzvC /usr/bin/ youki
+# curl -sSfL https://github.com/containers/youki/releases/download/v0.5.2/youki-0.5.2-$(uname -m)-musl.tar.gz | tar -xzvC /usr/bin/ youki
 ```
 <!--youki release end-->
 

--- a/experiment/selinux/src/selinux_label.rs
+++ b/experiment/selinux/src/selinux_label.rs
@@ -91,7 +91,7 @@ impl SELinux {
         label: SELinuxLabel,
     ) -> Result<(), SELinuxError> {
         let path = fpath.as_ref();
-        if !path.exists() {
+        if !path.is_symlink() && !path.exists() {
             return Err(SELinuxError::LSetFileLabel(ERR_EMPTY_PATH.to_string()));
         }
 

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"
 test_framework = { path = "../test_framework" }
-uuid = "1.14"
+uuid = "1.15"
 which = "7.0.2"
 tempfile = "3"
 scopeguard = "1.2.0"

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -11,7 +11,7 @@ libcontainer = { path = "../../../crates/libcontainer" }
 nix = "0.28.0"
 num_cpus = "1.16"
 oci-spec = { version = "0.7.1", features = ["runtime"] }
-once_cell = "1.21.0"
+once_cell = "1.21.1"
 pnet_datalink = "0.35.0"
 procfs = "0.17.0"
 rand = "0.9.0"

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -11,7 +11,7 @@ libcontainer = { path = "../../../crates/libcontainer" }
 nix = "0.28.0"
 num_cpus = "1.16"
 oci-spec = { version = "0.7.1", features = ["runtime"] }
-once_cell = "1.20.3"
+once_cell = "1.21.0"
 pnet_datalink = "0.35.0"
 procfs = "0.17.0"
 rand = "0.9.0"

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -9,6 +9,7 @@ use contest::logger;
 use test_framework::TestManager;
 use tests::cgroups;
 
+use crate::tests::delete::get_delete_test;
 use crate::tests::devices::get_devices_test;
 use crate::tests::domainname::get_domainname_tests;
 use crate::tests::example::get_example_test;
@@ -121,6 +122,7 @@ fn main() -> Result<()> {
     let sysctl = get_sysctl_test();
     let scheduler = get_scheduler_test();
     let io_priority_test = get_io_priority_test();
+    let delete = get_delete_test();
     let devices = get_devices_test();
     let root_readonly = get_root_readonly_test();
     let process = get_process_test();
@@ -153,6 +155,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(intel_rdt));
     tm.add_test_group(Box::new(sysctl));
     tm.add_test_group(Box::new(scheduler));
+    tm.add_test_group(Box::new(delete));
     tm.add_test_group(Box::new(devices));
     tm.add_test_group(Box::new(root_readonly));
     tm.add_test_group(Box::new(process));

--- a/tests/contest/contest/src/tests/delete/delete_test.rs
+++ b/tests/contest/contest/src/tests/delete/delete_test.rs
@@ -1,0 +1,184 @@
+use std::time::Duration;
+
+use anyhow::anyhow;
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::tests::lifecycle::ContainerLifecycle;
+
+// Default timeout for state transitions
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(75);
+
+/// Test deleting a non-existent container
+fn delete_non_existed_container() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    match container.delete() {
+        TestResult::Failed(_) => TestResult::Passed,
+        TestResult::Passed => TestResult::Failed(anyhow!(
+            "Expected deleting a non-existent container to fail, but it succeeded"
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    }
+}
+
+/// Test deleting a container in "created" state
+fn delete_created_container_test() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    // Create the container
+    match container.create() {
+        TestResult::Passed => {}
+        _ => return TestResult::Failed(anyhow!("Failed to create container")),
+    }
+
+    // Wait for the container to be in created state
+    match container.wait_for_state("created", DEFAULT_TIMEOUT) {
+        TestResult::Passed => {}
+        result => return result,
+    }
+
+    // Delete the container in "created" state
+    match container.delete() {
+        TestResult::Passed => TestResult::Passed,
+        TestResult::Failed(err) => TestResult::Failed(anyhow!(
+            "Failed to delete container in 'created' state: {}",
+            err
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    }
+}
+
+/// Test deleting a container in "running" state
+fn delete_running_container_test() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    // Create the container
+    match container.create() {
+        TestResult::Passed => {}
+        _ => return TestResult::Failed(anyhow!("Failed to create container")),
+    }
+
+    // Start the container
+    match container.start() {
+        TestResult::Passed => {}
+        _ => {
+            // Clean up and return error
+            let _ = container.kill();
+            let _ = container.wait_for_state("stopped", DEFAULT_TIMEOUT);
+            let _ = container.delete();
+            return TestResult::Failed(anyhow!("Failed to start container"));
+        }
+    }
+
+    // Wait for running state
+    match container.wait_for_state("running", DEFAULT_TIMEOUT) {
+        TestResult::Passed => {}
+        result => {
+            // Clean up and return error
+            let _ = container.kill();
+            let _ = container.wait_for_state("stopped", DEFAULT_TIMEOUT);
+            let _ = container.delete();
+            return result;
+        }
+    }
+
+    // Try to delete the running container (should fail per OCI spec)
+    let delete_result = match container.delete() {
+        TestResult::Failed(_) => TestResult::Passed,
+        TestResult::Passed => TestResult::Failed(anyhow!(
+            "Expected deleting a running container to fail, but it succeeded"
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    };
+
+    // Clean up
+    let _ = container.kill();
+    let _ = container.wait_for_state("stopped", DEFAULT_TIMEOUT);
+    let cleanup_result = container.delete();
+
+    // Return test result
+    match delete_result {
+        TestResult::Passed => cleanup_result,
+        _ => delete_result,
+    }
+}
+
+/// Test deleting a container in "stopped" state
+fn delete_stopped_container_test() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    // Create the container
+    match container.create() {
+        TestResult::Passed => {}
+        _ => return TestResult::Failed(anyhow!("Failed to create container")),
+    }
+
+    // Start the container
+    match container.start() {
+        TestResult::Passed => {}
+        _ => {
+            // Clean up and return error
+            let _ = container.kill();
+            let _ = container.wait_for_state("stopped", DEFAULT_TIMEOUT);
+            let _ = container.delete();
+            return TestResult::Failed(anyhow!("Failed to start container"));
+        }
+    }
+
+    // Stop the container
+    match container.kill() {
+        TestResult::Passed => {}
+        _ => {
+            // Clean up and return error
+            let _ = container.delete();
+            return TestResult::Failed(anyhow!("Failed to kill container"));
+        }
+    }
+
+    // Wait for stopped state
+    match container.wait_for_state("stopped", DEFAULT_TIMEOUT) {
+        TestResult::Passed => {}
+        result => return result,
+    }
+
+    // Delete the stopped container
+    match container.delete() {
+        TestResult::Passed => TestResult::Passed,
+        TestResult::Failed(err) => TestResult::Failed(anyhow!(
+            "Expected deleting a stopped container to succeed, but it failed: {}",
+            err
+        )),
+        _ => TestResult::Failed(anyhow!("Unexpected test result")),
+    }
+}
+
+/// Create and return the delete_container test group
+pub fn get_delete_test() -> TestGroup {
+    let mut test_group = TestGroup::new("delete");
+
+    let delete_non_existed_container = Test::new(
+        "delete_non_existed_container",
+        Box::new(delete_non_existed_container),
+    );
+    let delete_created_container_test = Test::new(
+        "delete_created_container_test",
+        Box::new(delete_created_container_test),
+    );
+    let delete_running_container_test = Test::new(
+        "delete_running_container_test",
+        Box::new(delete_running_container_test),
+    );
+    let delete_stopped_container_test = Test::new(
+        "delete_stopped_container_test",
+        Box::new(delete_stopped_container_test),
+    );
+
+    test_group.add(vec![
+        Box::new(delete_non_existed_container),
+        Box::new(delete_created_container_test),
+        Box::new(delete_running_container_test),
+        Box::new(delete_stopped_container_test),
+    ]);
+
+    test_group
+}

--- a/tests/contest/contest/src/tests/delete/mod.rs
+++ b/tests/contest/contest/src/tests/delete/mod.rs
@@ -1,0 +1,2 @@
+mod delete_test;
+pub use delete_test::get_delete_test;

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -86,6 +86,26 @@ impl ContainerLifecycle {
             &self.container_id,
         )
     }
+
+    /// Wait for the container to reach a specific state
+    pub fn wait_for_state(&self, expected_state: &str, timeout: Duration) -> TestResult {
+        use crate::tests::lifecycle::state;
+
+        match state::wait_for_state(
+            self.project_path.path(),
+            &self.container_id,
+            expected_state,
+            timeout,
+            Duration::from_millis(100),
+        ) {
+            Ok(_) => TestResult::Passed,
+            Err(e) => TestResult::Failed(anyhow::anyhow!(
+                "Container failed to reach {} state: {}",
+                expected_state,
+                e
+            )),
+        }
+    }
 }
 
 impl TestableGroup for ContainerLifecycle {

--- a/tests/contest/contest/src/tests/lifecycle/state.rs
+++ b/tests/contest/contest/src/tests/lifecycle/state.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
+use serde_json::Value;
 
 use crate::utils::get_state;
 
@@ -22,4 +23,79 @@ pub fn state(project_path: &Path, id: &str) -> Result<()> {
         }
         Err(e) => Err(e.context("failed to get container state")),
     }
+}
+
+/// Get the container status as a string
+pub fn get_container_status(project_path: &Path, id: &str) -> Result<String> {
+    match get_state(id, project_path) {
+        Ok((stdout, stderr)) => {
+            if stderr.contains("Error") || stderr.contains("error") {
+                bail!("Error :\nstdout : {}\nstderr : {}", stdout, stderr)
+            } else {
+                // Parse JSON to extract status
+                match serde_json::from_str::<Value>(&stdout) {
+                    Ok(value) => {
+                        if let Some(status) = value.get("status") {
+                            if let Some(status_str) = status.as_str() {
+                                return Ok(status_str.to_string());
+                            }
+                        }
+                        bail!("Failed to extract status from state output: {}", stdout)
+                    }
+                    Err(err) => bail!("Failed to parse state output as JSON: {} - {}", stdout, err),
+                }
+            }
+        }
+        Err(e) => Err(e.context("failed to get container state")),
+    }
+}
+
+/// Check if a container is in a specific state
+pub fn is_in_state(project_path: &Path, id: &str, expected_state: &str) -> Result<bool> {
+    match get_container_status(project_path, id) {
+        Ok(status) => Ok(status == expected_state),
+        Err(e) => {
+            // If the container doesn't exist, it's not in the expected state
+            if e.to_string().contains("does not exist") {
+                return Ok(false);
+            }
+            Err(e.context(format!(
+                "failed to check if container is in {} state",
+                expected_state
+            )))
+        }
+    }
+}
+
+/// Wait for a container to reach a specific state with timeout
+pub fn wait_for_state(
+    project_path: &Path,
+    id: &str,
+    expected_state: &str,
+    timeout: std::time::Duration,
+    poll_interval: std::time::Duration,
+) -> Result<()> {
+    let start = std::time::Instant::now();
+
+    while start.elapsed() < timeout {
+        match is_in_state(project_path, id, expected_state) {
+            Ok(true) => return Ok(()),
+            Ok(false) => std::thread::sleep(poll_interval),
+            Err(e) => {
+                // If there's a transient error, continue polling
+                if e.to_string().contains("does not exist") && expected_state == "stopped" {
+                    // Special case: if container doesn't exist and we're waiting for stopped state,
+                    // consider it stopped (deletion after stopping)
+                    return Ok(());
+                }
+                std::thread::sleep(poll_interval);
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "Timed out waiting for container {} to reach {} state",
+        id,
+        expected_state
+    ))
 }

--- a/tests/contest/contest/src/tests/linux_masked_paths/masked_paths.rs
+++ b/tests/contest/contest/src/tests/linux_masked_paths/masked_paths.rs
@@ -55,7 +55,7 @@ fn check_masked_paths() -> TestResult {
 
     let spec = get_spec(masked_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::fs;
         let test_dir = bundle_path.join(&masked_dir_sub);
         fs::create_dir_all(&test_dir)?;
@@ -87,7 +87,7 @@ fn check_masked_rel_paths() -> TestResult {
     let masked_paths = vec![masked_rel_path];
     let spec = get_spec(masked_paths);
 
-    let res = test_inside_container(spec, &CreateOptions::default(), &|_bundle_path| Ok(()));
+    let res = test_inside_container(&spec, &CreateOptions::default(), &|_bundle_path| Ok(()));
     // If the container creation succeeds, we expect an error since the masked paths does not support relative paths.
     if let TestResult::Passed = res {
         TestResult::Failed(anyhow!(
@@ -107,7 +107,7 @@ fn check_masked_symlinks() -> TestResult {
     let masked_paths = vec![root.join(MASKED_SYMLINK)];
     let spec = get_spec(masked_paths);
 
-    let res = test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    let res = test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::{fs, io};
         let test_file = bundle_path.join(MASKED_SYMLINK);
         // ln -s ../masked-symlink ; readlink -f /masked-symlink; ls -L /masked-symlink
@@ -162,7 +162,7 @@ fn test_mode(mode: u32) -> TestResult {
     let masked_paths = vec![root.join(MASKED_DEVICE)];
     let spec = get_spec(masked_paths);
 
-    test_inside_container(spec, &CreateOptions::default(), &|bundle_path| {
+    test_inside_container(&spec, &CreateOptions::default(), &|bundle_path| {
         use std::os::unix::fs::OpenOptionsExt;
         use std::{fs, io};
         let test_file = bundle_path.join(MASKED_DEVICE);

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod cgroups;
+pub mod delete;
 pub mod devices;
 pub mod domainname;
 pub mod example;

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 oci-spec = { version = "0.7.1", features = ["runtime"] }
 nix = "0.28.0"
 anyhow = "1.0"
-libc = "0.2.170" # TODO (YJDoc2) upgrade to latest
+libc = "0.2.171" # TODO (YJDoc2) upgrade to latest
 nc = "0.9.5"

--- a/tests/contest/test_framework/Cargo.toml
+++ b/tests/contest/test_framework/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.96"
+anyhow = "1.0.97"
 crossbeam = "0.8.4"


### PR DESCRIPTION
## Description
This PR implements two security best practices for our GitHub Actions workflow:
1. Adds GitHub Actions to Dependabot configuration for weekly dependency checks
2. Pins all GitHub Actions to specific SHA commits rather than using tags for improved security and reproducibility

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)
  - Verified Dependabot configuration syntax is valid
  - Confirmed GitHub Actions workflow runs successfully with pinned SHAs

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
Following GitHub security best practices, we've updated our workflow to pin GitHub Actions to specific SHAs instead of version tags. This prevents potential supply chain attacks where a tag could be modified to point to malicious code.

The Dependabot configuration now includes weekly checks for GitHub Actions updates to ensure we stay current with the latest security fixes while maintaining the ability to review changes before implementation.