### PR TITLE
fix: release ci tests also need apparmor disable

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Get changed files
         id: filter
         run: |
+          # grep will exit with non-zero if no matching pattern
+          # but we are ok with that, so to prevent workflow failing
+          # we set allow errors
+          set +e 
+
           # Change the base commit depending on event type
           if [[ "${{ github.event_name }}" == "push" ]]; then
             # For push events

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -23,6 +23,10 @@ jobs:
       - name: Get changed files
         id: filter
         run: |
+          # grep will exit with non-zero if no matching pattern
+          # but we are ok with that, so to prevent workflow failing
+          # we set allow errors
+          set +e 
           # Change the base commit depending on event type
           if [[ "${{ github.event_name }}" == "push" ]]; then
             # For push events

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,8 @@ jobs:
           echo "TARGET=${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}" >> ${GITHUB_ENV}
       - name: Release build
         run: just youki-release
+      - name: Disable AppArmor restrictions
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: test
         # TODO(utam0k): The feature test needs nightly
         # run: just test-basic featuretest test-oci


### PR DESCRIPTION
## Description
When we upgraded the CI to ubuntu 24.04 runners, we had to manually disable app armor restrictions for the tests. However the same was not done in release CI, so this PR fixes that.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
