### PR TITLE
bump nix to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,12 +447,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -576,7 +570,7 @@ dependencies = [
  "flate2",
  "libcgroups",
  "libcontainer",
- "nix 0.28.0",
+ "nix",
  "num_cpus",
  "oci-spec",
  "once_cell",
@@ -1994,7 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8306b516a70a129cb6afed17c1e51e162d35aadfcc6339364addcebe32de90"
 dependencies = [
  "cc",
- "nix 0.29.0",
+ "nix",
  "pkg-config",
 ]
 
@@ -2016,7 +2010,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "mockall",
- "nix 0.29.0",
+ "nix",
  "oci-spec",
  "procfs",
  "quickcheck",
@@ -2041,7 +2035,7 @@ dependencies = [
  "libcgroups",
  "libseccomp",
  "nc",
- "nix 0.29.0",
+ "nix",
  "oci-spec",
  "once_cell",
  "prctl",
@@ -2340,25 +2334,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -2770,7 +2752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.29.0",
+ "nix",
 ]
 
 [[package]]
@@ -3308,7 +3290,7 @@ dependencies = [
  "anyhow",
  "libc",
  "nc",
- "nix 0.29.0",
+ "nix",
  "oci-spec",
 ]
 
@@ -6068,7 +6050,7 @@ dependencies = [
  "libcgroups",
  "libcontainer",
  "liboci-cli",
- "nix 0.28.0",
+ "nix",
  "pentacle",
  "procfs",
  "scopeguard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,7 +2016,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "mockall",
- "nix 0.28.0",
+ "nix 0.29.0",
  "oci-spec",
  "procfs",
  "quickcheck",
@@ -2041,7 +2041,7 @@ dependencies = [
  "libcgroups",
  "libseccomp",
  "nc",
- "nix 0.28.0",
+ "nix 0.29.0",
  "oci-spec",
  "once_cell",
  "prctl",
@@ -2348,7 +2348,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
- "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2361,6 +2360,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -3308,7 +3308,7 @@ dependencies = [
  "anyhow",
  "libc",
  "nc",
- "nix 0.28.0",
+ "nix 0.29.0",
  "oci-spec",
 ]
 

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -20,7 +20,7 @@ systemd = ["v2", "nix/socket", "nix/uio"]
 cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc", "nix/dir"]
 
 [dependencies]
-nix = { version = "0.28.0", features = ["signal", "user", "fs"] }
+nix = { version = "0.29.0", features = ["signal", "user", "fs"] }
 procfs = "0.17.0"
 oci-spec = { version = "~0.7.1", features = ["runtime"] }
 fixedbitset = "0.5.7"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -27,7 +27,7 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 fastrand = "^2.3.0"
 libc = "0.2.171"
-nix = { version = "0.28.0", features = [
+nix = { version = "0.29.0", features = [
     "socket",
     "sched",
     "mount",

--- a/crates/libcontainer/src/channel.rs
+++ b/crates/libcontainer/src/channel.rs
@@ -123,7 +123,7 @@ where
         // there is only one SCM_RIGHTS message and will only process the first
         // message.
         let fds: Option<F> = msg
-            .cmsgs()
+            .cmsgs()?
             .find_map(|cmsg| {
                 if let socket::ControlMessageOwned::ScmRights(fds) = cmsg {
                     Some(fds)

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -33,7 +33,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.5.3" } # MARK: Version
 libcontainer = { path = "../libcontainer", default-features = false, version = "0.5.3" } # MARK: Version
 liboci-cli = { path = "../liboci-cli", version = "0.5.3" } # MARK: Version
-nix = "0.28.0"
+nix = "0.29.0"
 pentacle = "1.1.0"
 procfs = "0.17.0"
 serde_json = "1.0"

--- a/experiment/seccomp/Cargo.lock
+++ b/experiment/seccomp/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,9 +94,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "lock_api"
@@ -139,26 +145,27 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -263,7 +270,7 @@ name = "seccomp"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "nix 0.27.1",
+ "nix 0.29.0",
  "prctl",
  "syscall-numbers",
  "syscalls",

--- a/experiment/seccomp/Cargo.toml
+++ b/experiment/seccomp/Cargo.toml
@@ -12,7 +12,7 @@ autoexamples = true
 keywords = ["youki", "container", "seccomp"]
 
 [dependencies]
-nix = { version = "0.27.1", features = [
+nix = { version = "0.29.0", features = [
     "ioctl",
     "socket",
     "sched",

--- a/experiment/seccomp/src/main.rs
+++ b/experiment/seccomp/src/main.rs
@@ -38,7 +38,7 @@ fn recv_fd<F: FromRawFd>(sock: RawFd) -> nix::Result<Option<F>> {
 
     let mut cmsg_buf = nix::cmsg_space!(RawFd);
     let msg = socket::recvmsg::<UnixAddr>(sock, &mut iov, Some(&mut cmsg_buf), MsgFlags::empty())?;
-    match msg.cmsgs().next() {
+    match msg.cmsgs()?.next() {
         Some(ControlMessageOwned::ScmRights(fds)) if !fds.is_empty() => {
             let fd = unsafe { F::from_raw_fd(fds[0]) };
             Ok(Some(fd))

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0"
 flate2 = "1.1"
 libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
-nix = "0.28.0"
+nix = "0.29.0"
 num_cpus = "1.16"
 oci-spec = { version = "0.7.1", features = ["runtime"] }
 once_cell = "1.21.1"

--- a/tests/contest/contest/src/tests/seccomp_notify/seccomp_agent.rs
+++ b/tests/contest/contest/src/tests/seccomp_notify/seccomp_agent.rs
@@ -59,7 +59,7 @@ pub fn recv_seccomp_listener(seccomp_listener: &Path) -> SeccompAgentResult {
     drop(socket);
     // We are expecting 1 SCM_RIGHTS message with 1 fd.
     let cmsg = msg
-        .cmsgs()
+        .cmsgs()?
         .next()
         .context("expecting at least 1 SCM_RIGHTS message")?;
     let fd = match cmsg {

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 oci-spec = { version = "0.7.1", features = ["runtime"] }
-nix = "0.28.0"
+nix = "0.29.0"
 anyhow = "1.0"
 libc = "0.2.171" # TODO (YJDoc2) upgrade to latest
 nc = "0.9.5"


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Hi. This is a version bump for nix.

The main reason is that I'm looking for a rust cgroups crate, the `libcgroups` could be the best one I can find that works and has been maintained well.

However, the interface requires `fn add_task(&self, pid: Pid)` bind to nix 0.28, which could be tricky to work with if users use other versions.

So, I guess we can bump the version now. Later, maybe we could adjust the interface to make it more convenient for general purposes.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [x] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
