### PR TITLE
fix: wait on the create_process

### DIFF
--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -222,7 +222,12 @@ pub fn test_inside_container(
         .wait_with_output()
     {
         Ok(c) => c,
-        Err(e) => return TestResult::Failed(anyhow!("container start failed : {:?}", e)),
+        Err(e) => {
+            // given that start has failed, we can be pretty sure that create has either failed
+            // or completed already, so we wait on it so it does not become a zombie process
+            let _ = create_process.wait_with_output();
+            return TestResult::Failed(anyhow!("container start failed : {:?}", e));
+        }
     };
 
     let create_output = create_process

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -209,7 +209,7 @@ pub fn test_inside_container(
             .join("runtimetest"),
     )
     .unwrap();
-    let create_process = create_container(&id_str, &bundle, options).unwrap();
+    let mut create_process = create_container(&id_str, &bundle, options).unwrap();
     // here we do not wait for the process by calling wait() as in the test_outside_container
     // function because we need the output of the runtimetest. If we call wait, it will return
     // and we won't have an easy way of getting the stdio of the runtimetest.
@@ -224,7 +224,8 @@ pub fn test_inside_container(
         Ok(c) => c,
         Err(e) => {
             // given that start has failed, we can be pretty sure that create has either failed
-            // or completed already, so we wait on it so it does not become a zombie process
+            // or completed already, so we kill it and wait on it so it does not become a zombie process
+            let _ = create_process.kill();
             let _ = create_process.wait_with_output();
             return TestResult::Failed(anyhow!("container start failed : {:?}", e));
         }


### PR DESCRIPTION
## Description
This is in reference to https://github.com/youki-dev/youki/pull/3085#discussion_r1969531932

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
https://github.com/youki-dev/youki/pull/3085

## Additional Context
<!-- Add any other context about the pull request here -->
This is in order to fix a failing lint in the rust 1.85 , originally I had this in the same PR, but as suggested extracting into a separate PR.