### PR TITLE
libcontainer: Skip cgroup creation for rootless containers with cgroupfs

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -88,7 +88,8 @@ impl ContainerBuilderImpl {
         let cgroups_path = utils::get_cgroup_path(linux.cgroups_path(), &self.container_id);
         let cgroup_config = libcgroups::common::CgroupConfig {
             cgroup_path: cgroups_path,
-            systemd_cgroup: self.use_systemd || self.user_ns_config.is_some(),
+            systemd_cgroup: self.use_systemd,
+            rootless_container: self.user_ns_config.is_some(),
             container_name: self.container_id.to_owned(),
         };
         let process = self
@@ -212,15 +213,18 @@ impl ContainerBuilderImpl {
         let cmanager =
             libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
                 cgroup_path: cgroups_path,
-                systemd_cgroup: self.use_systemd || self.user_ns_config.is_some(),
+                systemd_cgroup: self.use_systemd,
+                rootless_container: self.user_ns_config.is_some(),
                 container_name: self.container_id.to_string(),
             })?;
 
         let mut errors = Vec::new();
 
-        if let Err(e) = cmanager.remove() {
-            tracing::error!(error = ?e, "failed to remove cgroup manager");
-            errors.push(e.to_string());
+        if let Some(cmanager) = cmanager {
+            if let Err(e) = cmanager.remove() {
+                tracing::error!(error = ?e, "failed to remove cgroup manager");
+                errors.push(e.to_string());
+            }
         }
 
         if let Some(container) = &self.container {

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -130,6 +130,15 @@ impl Container {
         self
     }
 
+    pub fn rootless(&self) -> bool {
+        self.state.is_rootless
+    }
+
+    pub fn set_rootless(&mut self, is_rootless: bool) -> &mut Self {
+        self.state.is_rootless = is_rootless;
+        self
+    }
+
     pub fn set_clean_up_intel_rdt_directory(&mut self, clean_up: bool) -> &mut Self {
         self.state.clean_up_intel_rdt_subdirectory = Some(clean_up);
         self

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -36,9 +36,12 @@ impl Container {
             libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
                 cgroup_path: self.spec()?.cgroup_path,
                 systemd_cgroup: self.systemd(),
+                rootless_container: self.rootless(),
                 container_name: self.id().to_string(),
             })?;
-        cmanager.freeze(FreezerState::Frozen)?;
+        if let Some(cmanager) = cmanager {
+            cmanager.freeze(FreezerState::Frozen)?;
+        }
 
         tracing::debug!("saving paused status");
         self.set_status(ContainerStatus::Paused).save()?;

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -37,10 +37,13 @@ impl Container {
             libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
                 cgroup_path: self.spec()?.cgroup_path,
                 systemd_cgroup: self.systemd(),
+                rootless_container: self.rootless(),
                 container_name: self.id().to_string(),
             })?;
         // resume the frozen container
-        cmanager.freeze(FreezerState::Thawed)?;
+        if let Some(cmanager) = cmanager {
+            cmanager.freeze(FreezerState::Thawed)?;
+        }
 
         tracing::debug!("saving running status");
         self.set_status(ContainerStatus::Running).save()?;

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -89,6 +89,7 @@ impl InitContainerBuilder {
         };
 
         let user_ns_config = UserNamespaceConfig::new(&spec)?;
+        container.set_rootless(user_ns_config.is_some());
 
         let config = YoukiConfig::from_spec(&spec, container.id())?;
         config.save(&container_dir).map_err(|err| {

--- a/crates/libcontainer/src/container/state.rs
+++ b/crates/libcontainer/src/container/state.rs
@@ -114,6 +114,8 @@ pub struct State {
     pub creator: Option<u32>,
     // Specifies if systemd should be used to manage cgroups
     pub use_systemd: bool,
+    // Specifies if the container is rootless.
+    pub is_rootless: bool,
     // Specifies if the Intel RDT subdirectory needs be cleaned up.
     pub clean_up_intel_rdt_subdirectory: Option<bool>,
 }
@@ -137,6 +139,7 @@ impl State {
             created: None,
             creator: None,
             use_systemd: false,
+            is_rootless: false,
             clean_up_intel_rdt_subdirectory: None,
         }
     }

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -62,11 +62,13 @@ pub fn container_intermediate_process(
     // In addition this needs to be done before we enter the cgroup namespace as
     // the cgroup of the process will form the root of the cgroup hierarchy in
     // the cgroup namespace.
-    apply_cgroups(
-        &cgroup_manager,
-        linux.resources().as_ref(),
-        matches!(args.container_type, ContainerType::InitContainer),
-    )?;
+    if let Some(cgroup_manager) = cgroup_manager {
+        apply_cgroups(
+            &cgroup_manager,
+            linux.resources().as_ref(),
+            matches!(args.container_type, ContainerType::InitContainer),
+        )?;
+    }
 
     // if new user is specified in specification, this will be true and new
     // namespace will be created, check

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -55,12 +55,13 @@ fn container_exists<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<
 fn create_cgroup_manager<P: AsRef<Path>>(
     root_path: P,
     container_id: &str,
-) -> Result<AnyCgroupManager> {
+) -> Result<Option<AnyCgroupManager>> {
     let container = load_container(root_path, container_id)?;
     Ok(libcgroups::common::create_cgroup_manager(
         libcgroups::common::CgroupConfig {
             cgroup_path: container.spec()?.cgroup_path,
             systemd_cgroup: container.systemd(),
+            rootless_container: container.rootless(),
             container_name: container.id().to_string(),
         },
     )?)

--- a/crates/youki/src/commands/ps.rs
+++ b/crates/youki/src/commands/ps.rs
@@ -10,37 +10,39 @@ use crate::commands::create_cgroup_manager;
 pub fn ps(args: Ps, root_path: PathBuf) -> Result<()> {
     let cmanager = create_cgroup_manager(root_path, &args.container_id)?;
 
-    let pids: Vec<i32> = cmanager
-        .get_all_pids()?
-        .iter()
-        .map(|pid| pid.as_raw())
-        .collect();
+    if let Some(cmanager) = cmanager {
+        let pids: Vec<i32> = cmanager
+            .get_all_pids()?
+            .iter()
+            .map(|pid| pid.as_raw())
+            .collect();
 
-    if args.format == "json" {
-        println!("{}", serde_json::to_string(&pids)?);
-    } else if args.format == "table" {
-        let default_ps_options = vec![String::from("-ef")];
-        let ps_options = if args.ps_options.is_empty() {
-            &default_ps_options
-        } else {
-            &args.ps_options
-        };
-        let output = Command::new("ps").args(ps_options).output()?;
-        if !output.status.success() {
-            println!("{}", std::str::from_utf8(&output.stderr)?);
-        } else {
-            let lines = std::str::from_utf8(&output.stdout)?;
-            let lines: Vec<&str> = lines.split('\n').collect();
-            let pid_index = get_pid_index(lines[0])?;
-            println!("{}", &lines[0]);
-            for line in &lines[1..] {
-                if line.is_empty() {
-                    continue;
-                }
-                let fields: Vec<&str> = line.split_whitespace().collect();
-                let pid: i32 = fields[pid_index].parse()?;
-                if pids.contains(&pid) {
-                    println!("{line}");
+        if args.format == "json" {
+            println!("{}", serde_json::to_string(&pids)?);
+        } else if args.format == "table" {
+            let default_ps_options = vec![String::from("-ef")];
+            let ps_options = if args.ps_options.is_empty() {
+                &default_ps_options
+            } else {
+                &args.ps_options
+            };
+            let output = Command::new("ps").args(ps_options).output()?;
+            if !output.status.success() {
+                println!("{}", std::str::from_utf8(&output.stderr)?);
+            } else {
+                let lines = std::str::from_utf8(&output.stdout)?;
+                let lines: Vec<&str> = lines.split('\n').collect();
+                let pid_index = get_pid_index(lines[0])?;
+                println!("{}", &lines[0]);
+                for line in &lines[1..] {
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let fields: Vec<&str> = line.split_whitespace().collect();
+                    let pid: i32 = fields[pid_index].parse()?;
+                    if pids.contains(&pid) {
+                        println!("{line}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Creating cgroups with cgroupfs as non-root is not possible. Before this change, we used to enforce systemd as a cgroup manager for all rootless containers, but that prevents the usage of rootless youki on systems wuthout systemd. To make such usage possible, raise a warning and skip cgroup-related activities instead. That matches the behavior of crun (containers/crun#97).

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3144

## Additional Context
<!-- Add any other context about the pull request here -->
