### PR TITLE
Fixed grammatical error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ youki is named after the Japanese word 'youki', which means 'a container'. In Ja
 
 Here is why we are writing a new container runtime in Rust.
 
-- Rust is one of the best languages to implement the oci-runtime spec. Many very nice container tools are currently written in Go. However, the container runtime requires the use of system calls, which requires a bit of special handling when implemented in Go. This tricky (e.g. _namespaces(7)_, _fork(2)_); with Rust too, but it's not that tricky. And, unlike in C, Rust provides the benefit of memory safety. While Rust is not yet a major player in the container field, it has the potential to contribute a lot: something this project attempts to exemplify.
+- Rust is one of the best languages to implement the oci-runtime spec. Many very nice container tools are currently written in Go. However, the container runtime requires the use of system calls, which requires a bit of special handling when implemented in Go. This is tricky (e.g. _namespaces(7)_, _fork(2)_); with Rust too, but it's not that tricky. And, unlike in C, Rust provides the benefit of memory safety. While Rust is not yet a major player in the container field, it has the potential to contribute a lot: something this project attempts to exemplify.
 - youki has the potential to be faster and use less memory than runc, and therefore work in environments with tight memory usage requirements. Here is a simple benchmark of a container from creation to deletion.
   |  Runtime | Time (mean ± σ) | 	Range (min … max) | vs youki(mean) | Version | 
   | -------- | -------- | -------- | -------- | -------- |


### PR DESCRIPTION
## Description
Fixed a grammatical error on line 37 of the README

"This tricky (e.g. _namespaces(7)_, _fork(2)_); with Rust too, but it's not that tricky." -> "This __is__ tricky (e.g. _namespaces(7)_, _fork(2)_); with Rust too, but it's not that tricky."

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
No issues, just saw it while reading the README.

## Additional Context
<!-- Add any other context about the pull request here -->
N/A