### PR TITLE
add support exec-cpu-affinity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
  "pnet_datalink",
  "procfs",
  "rand 0.9.1",
+ "regex",
  "scopeguard",
  "serde",
  "serde_json",

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -447,6 +447,12 @@ impl TenantContainerBuilder {
                 process_builder = process_builder.cwd(cwd);
             }
 
+            if let Some(process) = spec.process() {
+                if let Some(cpu_affinity) = process.exec_cpu_affinity() {
+                    process_builder = process_builder.exec_cpu_affinity(cpu_affinity.clone());
+                }
+            }
+
             if let Some(no_new_priv) = self.get_no_new_privileges() {
                 process_builder = process_builder.no_new_privileges(no_new_priv);
             }

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -11,7 +11,7 @@ use super::container_init_process::container_init_process;
 use super::fork::CloneCb;
 use crate::error::MissingSpecError;
 use crate::namespaces::Namespaces;
-use crate::process::{channel, fork};
+use crate::process::{channel, cpu_affinity, fork};
 
 #[derive(Debug, thiserror::Error)]
 pub enum IntermediateProcessError {
@@ -31,6 +31,8 @@ pub enum IntermediateProcessError {
     ExecNotify(#[source] nix::Error),
     #[error(transparent)]
     MissingSpec(#[from] crate::error::MissingSpecError),
+    #[error("CPU affinity error {0}")]
+    CpuAffinity(#[from] cpu_affinity::CPUAffinityError),
     #[error("other error")]
     Other(String),
 }
@@ -52,6 +54,21 @@ pub fn container_intermediate_process(
     let cgroup_manager = libcgroups::common::create_cgroup_manager(args.cgroup_config.to_owned())
         .map_err(|e| IntermediateProcessError::Cgroup(e.to_string()))?;
 
+    let current_pid = Pid::this();
+    // setting CPU affinity for tenant container before cgroup move
+    if matches!(args.container_type, ContainerType::TenantContainer { .. }) {
+        if let Some(exec_cpu_affinity) = spec
+            .process()
+            .as_ref()
+            .and_then(|p| p.exec_cpu_affinity().as_ref())
+        {
+            if let Some(initial) = exec_cpu_affinity.initial() {
+                cpu_affinity::set_cpuset_affinity_from_string(current_pid, initial)?;
+            }
+        }
+    }
+    let _ = cpu_affinity::log_cpu_affinity();
+
     // this needs to be done before we create the init process, so that the init
     // process will already be captured by the cgroup. It also needs to be done
     // before we enter the user namespace because if a privileged user starts a
@@ -67,6 +84,19 @@ pub fn container_intermediate_process(
         linux.resources().as_ref(),
         matches!(args.container_type, ContainerType::InitContainer),
     )?;
+
+    // setting CPU affinity for tenant container after cgroup move
+    if matches!(args.container_type, ContainerType::TenantContainer { .. }) {
+        if let Some(exec_cpu_affinity) = spec
+            .process()
+            .as_ref()
+            .and_then(|p| p.exec_cpu_affinity().as_ref())
+        {
+            if let Some(cpu_affinity_final) = exec_cpu_affinity.cpu_affinity_final() {
+                cpu_affinity::set_cpuset_affinity_from_string(current_pid, cpu_affinity_final)?;
+            }
+        }
+    }
 
     // if new user is specified in specification, this will be true and new
     // namespace will be created, check

--- a/crates/libcontainer/src/process/cpu_affinity.rs
+++ b/crates/libcontainer/src/process/cpu_affinity.rs
@@ -1,0 +1,156 @@
+use nix::sched::{sched_getaffinity, sched_setaffinity, CpuSet};
+use nix::unistd::Pid;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CPUAffinityError {
+    #[error("invalid CPU string: {0}")]
+    ParseError(String),
+    #[error("values larger than {max} are not supported")]
+    CpuOutOfRange { cpu: usize, max: usize },
+    #[error("failed to set CPU for CPU {cpu}: {source}")]
+    CpuSet {
+        cpu: usize,
+        #[source]
+        source: nix::Error,
+    },
+    #[error("failed to setaffinity")]
+    SetAffinity(#[source] nix::Error),
+    #[error("failed to getaffinity")]
+    GetAffinity(#[source] nix::Error),
+}
+
+type Result<T> = std::result::Result<T, CPUAffinityError>;
+
+pub fn to_cpuset(cpuset_str: &str) -> Result<CpuSet> {
+    let mut cpuset = CpuSet::new();
+    let max_cpu = CpuSet::count();
+
+    for part in cpuset_str
+        .trim()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        match part.split_once('-') {
+            Some((start_str, end_str)) => {
+                let start = parse_cpu_index(start_str, max_cpu)?;
+                let end = parse_cpu_index(end_str, max_cpu)?;
+                if start > end {
+                    return Err(CPUAffinityError::ParseError(format!(
+                        "invalid range: {}-{}",
+                        start, end
+                    )));
+                }
+                for cpu in start..=end {
+                    cpuset
+                        .set(cpu)
+                        .map_err(|e| CPUAffinityError::CpuSet { cpu, source: e })?;
+                }
+            }
+            None => {
+                let cpu = parse_cpu_index(part, max_cpu)?;
+                cpuset
+                    .set(cpu)
+                    .map_err(|e| CPUAffinityError::CpuSet { cpu, source: e })?;
+            }
+        }
+    }
+    Ok(cpuset)
+}
+
+fn parse_cpu_index(s: &str, max_cpu: usize) -> Result<usize> {
+    let cpu: usize = s
+        .parse()
+        .map_err(|_| CPUAffinityError::ParseError(s.to_string()))?;
+    if cpu >= max_cpu {
+        return Err(CPUAffinityError::CpuOutOfRange {
+            cpu,
+            max: max_cpu - 1,
+        });
+    }
+    Ok(cpu)
+}
+
+pub fn set_cpuset_affinity_from_string(pid: Pid, cpuset_str: &str) -> Result<()> {
+    tracing::debug!(?cpuset_str, "setting CPU affinity for tenant container");
+    sched_setaffinity(pid, &to_cpuset(cpuset_str)?).map_err(CPUAffinityError::SetAffinity)
+}
+
+pub fn log_cpu_affinity() -> Result<()> {
+    let cpuset = sched_getaffinity(Pid::this()).map_err(CPUAffinityError::GetAffinity)?;
+    let mask = (0..usize::BITS as usize)
+        .filter(|&i| cpuset.is_set(i).unwrap_or(false))
+        .fold(0, |mask, i| mask | (1 << i));
+    tracing::debug!("affinity: 0x{:x}", mask);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_cpuset_single_values() {
+        let cpuset = to_cpuset("0,1,2").unwrap();
+        for cpu in [0, 1, 2] {
+            assert!(cpuset.is_set(cpu).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_to_cpuset_range() {
+        let cpuset = to_cpuset("3-5").unwrap();
+        for cpu in [3, 4, 5] {
+            assert!(cpuset.is_set(cpu).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_to_cpuset_mixed() {
+        let cpuset = to_cpuset("0, 2-4, 6").unwrap();
+        for cpu in [0, 2, 3, 4, 6] {
+            assert!(cpuset.is_set(cpu).unwrap());
+        }
+        for cpu in [1, 5, 7] {
+            assert!(!cpuset.is_set(cpu).unwrap_or(false));
+        }
+    }
+
+    #[test]
+    fn test_to_cpuset_spaces_and_empty() {
+        let cpuset = to_cpuset("  , 1 , 3 , 5-7 , ").unwrap();
+        for cpu in [1, 3, 5, 6, 7] {
+            assert!(cpuset.is_set(cpu).unwrap());
+        }
+    }
+
+    #[test]
+    fn test_to_cpuset_invalid_range() {
+        let err = to_cpuset("5-3").unwrap_err();
+        matches!(err, CPUAffinityError::ParseError(_));
+    }
+
+    #[test]
+    fn test_to_cpuset_invalid_value() {
+        let err = to_cpuset("a,b,c").unwrap_err();
+        matches!(err, CPUAffinityError::ParseError(_));
+    }
+
+    #[test]
+    fn test_to_cpuset_max_allowed_cpu() {
+        let max = CpuSet::count();
+        let highest = max - 1;
+        let cpuset = to_cpuset(&highest.to_string()).unwrap();
+        assert!(cpuset.is_set(highest).unwrap());
+    }
+
+    #[test]
+    fn test_to_cpuset_exceeds_max_cpu() {
+        let max = CpuSet::count();
+        let result = to_cpuset(&max.to_string());
+        assert!(matches!(
+            result,
+            Err(CPUAffinityError::CpuOutOfRange { .. })
+        ));
+    }
+}

--- a/crates/libcontainer/src/process/mod.rs
+++ b/crates/libcontainer/src/process/mod.rs
@@ -6,6 +6,7 @@ pub mod channel;
 pub mod container_init_process;
 pub mod container_intermediate_process;
 pub mod container_main_process;
+pub mod cpu_affinity;
 mod fork;
 pub mod intel_rdt;
 mod message;

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -25,6 +25,7 @@ tempfile = "3"
 scopeguard = "1.2.0"
 tracing = { version = "0.1.41", features = ["attributes"]}
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
+regex = "1"
 
 [dependencies.clap]
 version = "4.1.6"

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -13,6 +13,7 @@ use crate::tests::delete::get_delete_test;
 use crate::tests::devices::get_devices_test;
 use crate::tests::domainname::get_domainname_tests;
 use crate::tests::example::get_example_test;
+use crate::tests::exec_cpu_affinity::get_exec_cpu_affinity_test;
 use crate::tests::fd_control::get_fd_control_test;
 use crate::tests::hooks::get_hooks_tests;
 use crate::tests::hostname::get_hostname_test;
@@ -136,6 +137,7 @@ fn main() -> Result<()> {
     let fd_control = get_fd_control_test();
     let masked_paths = get_linux_masked_paths_tests();
     let rootfs_propagation = get_rootfs_propagation_test();
+    let exec_cpu_affinity = get_exec_cpu_affinity_test();
 
     tm.add_test_group(Box::new(cl));
     tm.add_test_group(Box::new(cc));
@@ -171,6 +173,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(process_oom_score_adj));
     tm.add_test_group(Box::new(fd_control));
     tm.add_test_group(Box::new(rootfs_propagation));
+    tm.add_test_group(Box::new(exec_cpu_affinity));
 
     tm.add_test_group(Box::new(io_priority_test));
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));

--- a/tests/contest/contest/src/tests/exec_cpu_affinity/exec_cpu_affinity_test.rs
+++ b/tests/contest/contest/src/tests/exec_cpu_affinity/exec_cpu_affinity_test.rs
@@ -1,0 +1,254 @@
+use std::fs;
+
+use anyhow::{anyhow, Context, Result};
+use oci_spec::runtime::{ExecCPUAffinityBuilder, ProcessBuilder, Spec, SpecBuilder};
+use regex::Regex;
+use serde_json::{json, Value};
+use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
+
+use crate::utils::{exec_container, is_runtime_runc, start_container, test_outside_container};
+
+fn create_spec(initial: Option<&str>, fin: Option<&str>) -> Result<Spec> {
+    let mut builder = ExecCPUAffinityBuilder::default();
+    if let Some(i) = initial {
+        builder = builder.initial(i.to_string());
+    }
+    if let Some(f) = fin {
+        builder = builder.cpu_affinity_final(f.to_string());
+    }
+
+    let cpu_affinity = builder.build()?;
+
+    SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["sleep".to_string(), "10000".to_string()])
+                .exec_cpu_affinity(cpu_affinity)
+                .build()?,
+        )
+        .build()
+        .context("failed to create spec")
+}
+
+fn test_cpu_affinity_only_initial_set_from_process_json() -> TestResult {
+    let spec = test_result!(create_spec(None, None));
+    test_outside_container(&spec, &|data| {
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let process_affinity_initial = "0,1";
+        let process_json = create_process(Some(process_affinity_initial), None);
+
+        let process_path = dir.join("process.json");
+        if let Err(e) = fs::write(
+            &process_path,
+            serde_json::to_vec_pretty(&process_json).unwrap(),
+        ) {
+            return TestResult::Failed(anyhow!("failed to write process.json: {}", e));
+        }
+
+        let (_stdout, stderr) = match exec_container(id, dir, &["/bin/true"], Some(&process_path)) {
+            Ok(output) => output,
+            Err(e) => return TestResult::Failed(e),
+        };
+
+        let mask = affinity_mask_from_str(process_affinity_initial);
+        let pattern = format!(r".*affinity: 0x{:x}", mask);
+        let re = Regex::new(&pattern).unwrap();
+        if !re.is_match(&stderr) {
+            return TestResult::Failed(anyhow!(
+                "missing expected affinity log in stderr: {}",
+                stderr
+            ));
+        }
+
+        TestResult::Passed
+    })
+}
+
+fn test_cpu_affinity_initial_and_final_set_from_process_json() -> TestResult {
+    let spec = test_result!(create_spec(None, None));
+    test_outside_container(&spec, &|data| {
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let process_affinity_initial = "0";
+        let process_affinity_final = "1";
+        let process_json =
+            create_process(Some(process_affinity_initial), Some(process_affinity_final));
+
+        let process_path = dir.join("process.json");
+        if let Err(e) = fs::write(
+            &process_path,
+            serde_json::to_vec_pretty(&process_json).unwrap(),
+        ) {
+            return TestResult::Failed(anyhow!("failed to write process.json: {}", e));
+        }
+
+        let (stdout, stderr) = match exec_container(
+            id,
+            dir,
+            &["grep", "Cpus_allowed_list", "/proc/self/status"],
+            Some(&process_path),
+        ) {
+            Ok(output) => output,
+            Err(e) => return TestResult::Failed(e),
+        };
+
+        if !stdout.contains(process_affinity_final) {
+            return TestResult::Failed(anyhow!("unexpected Cpus_allowed_list: {}", stdout));
+        }
+
+        let mask = affinity_mask_from_str(process_affinity_initial);
+        let pattern = format!(r".*affinity: 0x{:x}", mask);
+        let re = Regex::new(&pattern).unwrap();
+        if !re.is_match(&stderr) {
+            return TestResult::Failed(anyhow!(
+                "missing expected affinity log in stderr: {}",
+                stderr
+            ));
+        }
+
+        TestResult::Passed
+    })
+}
+
+fn test_cpu_affinity_from_config_json() -> TestResult {
+    let affinity_initial = "0";
+    let affinity_final = "1";
+
+    let spec = test_result!(create_spec(Some(affinity_initial), Some(affinity_final)));
+    test_outside_container(&spec, &|data| {
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let (stdout, stderr) = exec_container(
+            id,
+            dir,
+            &["grep", "Cpus_allowed_list", "/proc/self/status"],
+            None,
+        )
+        .expect("exec failed");
+
+        if !stdout.contains(affinity_final) {
+            return TestResult::Failed(anyhow!("unexpected Cpus_allowed_list: {}", stdout));
+        }
+
+        let mask = affinity_mask_from_str(affinity_initial);
+        let pattern = format!(r".*affinity: 0x{:x}", mask);
+        let re = Regex::new(&pattern).unwrap();
+        if !re.is_match(&stderr) {
+            return TestResult::Failed(anyhow!(
+                "missing expected affinity log in stderr: {}",
+                stderr
+            ));
+        }
+
+        TestResult::Passed
+    })
+}
+
+// In runc, `exec_cpu_affinity` is introduced in version 1.3.0.
+// Since the current CI uses an older version of runc, `exec_cpu_affinity` is not available and the test will be skipped.
+// youki/.github/workflows/integration_tests_validation.yaml:95
+// https://github.com/opencontainers/runc/releases/tag/v1.3.0-rc.1
+pub fn get_exec_cpu_affinity_test() -> TestGroup {
+    let mut exec_cpu_affinity_test_group = TestGroup::new("exec_cpu_affinity");
+
+    let test_cpu_affinity_only_initial_set_from_process_json = ConditionalTest::new(
+        "test_cpu_affinity_only_initial_set_from_process_json",
+        Box::new(|| !is_runtime_runc()),
+        Box::new(test_cpu_affinity_only_initial_set_from_process_json),
+    );
+    let test_cpu_affinity_initial_and_final_set_from_process_json = ConditionalTest::new(
+        "test_cpu_affinity_initial_and_final_set_from_process_json",
+        Box::new(|| !is_runtime_runc()),
+        Box::new(test_cpu_affinity_initial_and_final_set_from_process_json),
+    );
+    let test_cpu_affinity_from_config_json = ConditionalTest::new(
+        "test_cpu_affinity_from_config_json",
+        Box::new(|| !is_runtime_runc()),
+        Box::new(test_cpu_affinity_from_config_json),
+    );
+    exec_cpu_affinity_test_group.add(vec![
+        Box::new(test_cpu_affinity_only_initial_set_from_process_json),
+        Box::new(test_cpu_affinity_initial_and_final_set_from_process_json),
+        Box::new(test_cpu_affinity_from_config_json),
+    ]);
+
+    exec_cpu_affinity_test_group
+}
+
+pub fn create_process(
+    cpu_affinity_initial: Option<&str>,
+    cpu_affinity_final: Option<&str>,
+) -> Value {
+    let mut exec_cpu_affinity = serde_json::Map::new();
+
+    if let Some(init) = cpu_affinity_initial {
+        exec_cpu_affinity.insert("initial".to_string(), json!(init));
+    }
+    if let Some(fin) = cpu_affinity_final {
+        exec_cpu_affinity.insert("final".to_string(), json!(fin));
+    }
+
+    let exec_cpu_affinity_value = Value::Object(exec_cpu_affinity);
+
+    json!({
+        "terminal": false,
+        "cwd": "/",
+        "args": [
+            "/bin/grep",
+            "-F",
+            "Cpus_allowed_list:",
+            "/proc/self/status"
+        ],
+        "env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "TERM=xterm"
+        ],
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "execCPUAffinity": exec_cpu_affinity_value
+    })
+}
+
+fn affinity_mask_from_str(cpuset_str: &str) -> u64 {
+    let mut mask = 0u64;
+
+    for part in cpuset_str.trim().split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        if let Some((start, end)) = part.split_once('-') {
+            let start: usize = start.parse().unwrap();
+            let end: usize = end.parse().unwrap();
+            for i in start..=end {
+                mask |= 1 << i;
+            }
+        } else {
+            let cpu: usize = part.parse().unwrap();
+            mask |= 1 << cpu;
+        }
+    }
+
+    mask
+}

--- a/tests/contest/contest/src/tests/exec_cpu_affinity/mod.rs
+++ b/tests/contest/contest/src/tests/exec_cpu_affinity/mod.rs
@@ -1,0 +1,2 @@
+mod exec_cpu_affinity_test;
+pub use exec_cpu_affinity_test::get_exec_cpu_affinity_test;

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -3,6 +3,7 @@ pub mod delete;
 pub mod devices;
 pub mod domainname;
 pub mod example;
+pub mod exec_cpu_affinity;
 pub mod fd_control;
 pub mod hooks;
 pub mod hostname;

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -6,6 +6,6 @@ pub use support::{
     set_config,
 };
 pub use test_utils::{
-    create_container, delete_container, get_state, kill_container, test_inside_container,
-    test_outside_container, CreateOptions, State,
+    create_container, delete_container, exec_container, get_state, kill_container, start_container,
+    test_inside_container, test_outside_container, CreateOptions, State,
 };

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -41,6 +41,7 @@ pub struct ContainerData {
     pub state: Option<State>,
     pub state_err: String,
     pub create_result: std::io::Result<ExitStatus>,
+    pub bundle: PathBuf,
 }
 
 #[derive(Debug, Default)]
@@ -164,6 +165,7 @@ pub fn test_outside_container(
         state,
         state_err: err,
         create_result,
+        bundle: bundle.path().to_path_buf(),
     };
     let test_result = execute_test(data);
     kill_container(&id_str, &bundle).unwrap().wait().unwrap();
@@ -311,4 +313,39 @@ pub fn check_container_created(data: &ContainerData) -> Result<()> {
         }
         Err(e) => Err(anyhow!("{}", e)),
     }
+}
+
+pub fn exec_container<P: AsRef<Path>>(
+    id: &str,
+    dir: P,
+    args: &[impl AsRef<OsStr>],
+    process_path: Option<&Path>,
+) -> Result<(String, String)> {
+    let mut command = runtime_command(&dir);
+    command.arg("--debug").arg("exec");
+
+    if let Some(path) = process_path {
+        command.arg("--process").arg(path);
+    }
+
+    command.arg(id);
+
+    if process_path.is_none() {
+        command.args(args);
+    }
+
+    let output = command.output().context("failed to run exec")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if !output.status.success() {
+        bail!(
+            "exec failed with status: {:?}, stderr: {}",
+            output.status,
+            stderr
+        );
+    }
+
+    Ok((stdout, stderr))
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Add cpu affinity setting to the executed process.
Based on the following code, I added support for setting cpu affinity in Youki.
The implementation sets cpu affinity both before and after moving the intermediate process into the cgroup.
I also created tests based on the test cases from runc.

- [runtime-spec](https://github.com/opencontainers/runtime-spec/blob/main/config.md#linux-process)
- [runc](https://github.com/kolyshkin/runc/commit/10ca66bff51f5b2b360842b837848e2ec2fe930e#diff-77e4825ebd271071c5c47a3774307985b3adc6914f4a1e76a739e249f6944b80)
- [crun](https://github.com/containers/crun/commit/ef33259c7769e91dbf8eea2eb6aabe8e253b6376)

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)


## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #2795 

## Additional Context
<!-- Add any other context about the pull request here -->
In runc, `exec_cpu_affinity` is introduced in version [1.3.0](https://github.com/opencontainers/runc/releases/tag/v1.3.0-rc.1).
Since the current CI uses an older version of runc[1.1.11](https://github.com/youki-dev/youki/blob/f9b6355cb5c54b271d82110fe03875e2dd677c93/.github/workflows/integration_tests_validation.yaml#L95), `exec_cpu_affinity` is not available and the test(just validate-contest-runc) will be skipped. The tests passed successfully when using runc version 1.3.0-rc.1.

