### PR TITLE
allow running selected tests in contest.sh and justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,12 +54,12 @@ test-oci:
     {{ cwd }}/scripts/oci_integration_tests.sh {{ cwd }}
 
 # run rust oci integration tests
-test-contest: youki-release contest
-    sudo {{ cwd }}/scripts/contest.sh {{ cwd }}/youki
+test-contest *TESTNAME: youki-release contest
+    sudo {{ cwd }}/scripts/contest.sh {{ cwd }}/youki {{TESTNAME}}
 
 # validate rust oci integration tests on runc
-validate-contest-runc: contest
-    sudo RUNTIME_KIND="runc" {{ cwd }}/scripts/contest.sh runc
+validate-contest-runc *TESTNAME: contest
+    sudo RUNTIME_KIND="runc" {{ cwd }}/scripts/contest.sh runc {{TESTNAME}}
 
 # test podman rootless works with youki
 test-rootless-podman:
@@ -202,3 +202,6 @@ version-up version:
     sed -i "s/{{version}}/$NEXT_VERSION/g" .tagpr
     # Need to update the lockfile.
     cargo check
+
+contest-list: contest
+   {{ cwd }}/contest list

--- a/scripts/contest.sh
+++ b/scripts/contest.sh
@@ -2,6 +2,7 @@
 
 ROOT=$(git rev-parse --show-toplevel)
 RUNTIME=$1
+shift
 
 if [ "$RUNTIME" = "" ]; then
     echo "please specify runtime"
@@ -15,8 +16,6 @@ if [ ! -e $RUNTIME ]; then
   fi
 fi
 
-ROOT=${2-$(git rev-parse --show-toplevel)}
-
 LOGFILE="${ROOT}/test.log"
 
 if [ ! -f ${ROOT}/bundle.tar.gz ]; then
@@ -24,14 +23,18 @@ if [ ! -f ${ROOT}/bundle.tar.gz ]; then
 fi
 touch ${LOGFILE}
 
-${ROOT}/contest run --runtime "$RUNTIME" --runtimetest ${ROOT}/runtimetest > $LOGFILE
+if [ $# -gt 0 ]; then
+    ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest "${ROOT}/runtimetest" -t "$@" > "$LOGFILE"
+else
+    ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest "${ROOT}/runtimetest" > "$LOGFILE"
+fi
 
 if [ 0 -ne $(grep "not ok" $LOGFILE | wc -l ) ]; then
     cat $LOGFILE
     exit 1
 fi
 
-echo "Validation successful for runtime $1"
+echo "Validation successful for runtime $RUNTIME"
 exit 0
 
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This pull request improves the usability of integration test from the justfile.
It enables test case selection for two commands: `test-contest` and `validate-contest-runc`.

The `contest` binary already provides a `run_selected` function to run specific test cases(`contest run -t example...`), and this change makes it accessible via just commands.
If no arguments are provided, all tests will be executed as usual, so the existing CI will not be affected.

This is especially useful for local development, where running the entire test suite can be time-consuming and impact productivity.
This PR aims to improve development efficiency by allowing selective test execution.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

just test-contest(example selected)
```
$ just test-contest example
/home/ubuntu/workspace/youki/scripts/build.sh -o /home/ubuntu/workspace/youki -r -c youki
* FEATURES: <default>
* TARGET: x86_64-unknown-linux-gnu
   Compiling youki v0.5.3 (/home/ubuntu/workspace/youki/crates/youki)
    Finished `release` profile [optimized] target(s) in 1m 09s
/home/ubuntu/workspace/youki/scripts/build.sh -o /home/ubuntu/workspace/youki -r -c contest
* FEATURES: <default>
* TARGET: x86_64-unknown-linux-gnu
removed '/home/ubuntu/workspace/youki/contest'
    Finished `release` profile [optimized] target(s) in 0.20s
removed '/home/ubuntu/workspace/youki/runtimetest'
    Finished `release` profile [optimized] target(s) in 0.20s
sudo /home/ubuntu/workspace/youki/scripts/contest.sh /home/ubuntu/workspace/youki/youki example
Validation successful for runtime /home/ubuntu/workspace/youki/youki
```

validate-contest-runc(example selected)
```
$ just validate-contest-runc example
/home/ubuntu/workspace/youki/scripts/build.sh -o /home/ubuntu/workspace/youki -r -c contest
* FEATURES: <default>
* TARGET: x86_64-unknown-linux-gnu
removed '/home/ubuntu/workspace/youki/contest'
    Finished `release` profile [optimized] target(s) in 0.22s
removed '/home/ubuntu/workspace/youki/runtimetest'
   Compiling runtimetest v0.0.1 (/home/ubuntu/workspace/youki/tests/contest/runtimetest)
    Finished `release` profile [optimized] target(s) in 28.78s
sudo RUNTIME_KIND="runc" /home/ubuntu/workspace/youki/scripts/contest.sh runc example
/usr/local/sbin/runc
Validation successful for runtime runc
```

multi selected

```
$ just validate-contest-runc example fd_control
/home/ubuntu/workspace/youki/scripts/build.sh -o /home/ubuntu/workspace/youki -r -c contest
* FEATURES: <default>
* TARGET: x86_64-unknown-linux-gnu
removed '/home/ubuntu/workspace/youki/contest'
    Finished `release` profile [optimized] target(s) in 0.22s
removed '/home/ubuntu/workspace/youki/runtimetest'
    Finished `release` profile [optimized] target(s) in 0.19s
sudo RUNTIME_KIND="runc" /home/ubuntu/workspace/youki/scripts/contest.sh runc example fd_control
/usr/local/sbin/runc
Validation successful for runtime runc
```

all test

It has been confirmed that the executed command is sudo /home/ubuntu/workspace/youki/scripts/contest.sh /home/ubuntu/workspace/youki/youki, which is the same as before.

```
$ just test-contest 
/home/ubuntu/workspace/youki/scripts/build.sh -o /home/ubuntu/workspace/youki -r -c youki
* FEATURES: <default>
* TARGET: x86_64-unknown-linux-gnu
    Finished `release` profile [optimized] target(s) in 0.20s
/home/ubuntu/workspace/youki/scripts/build.sh -o /home/ubuntu/workspace/youki -r -c contest
* FEATURES: <default>
* TARGET: x86_64-unknown-linux-gnu
removed '/home/ubuntu/workspace/youki/contest'
    Finished `release` profile [optimized] target(s) in 0.20s
removed '/home/ubuntu/workspace/youki/runtimetest'
    Finished `release` profile [optimized] target(s) in 0.19s
sudo /home/ubuntu/workspace/youki/scripts/contest.sh /home/ubuntu/workspace/youki/youki 

...
```


## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
