### PR TITLE
fix: remove println statements from contest tests

### DIFF
--- a/tests/contest/contest/src/tests/mounts_recursive/mod.rs
+++ b/tests/contest/contest/src/tests/mounts_recursive/mod.rs
@@ -553,14 +553,12 @@ fn check_recursive_rnosymfollow() -> TestResult {
         let original_file_path = format!("{}/{}", rnosymfollow_dir_path.to_str().unwrap(), "file");
         let file = File::create(&original_file_path)?;
         let link_file_path = format!("{}/{}", rnosymfollow_dir_path.to_str().unwrap(), "link");
-        println!("original file: {original_file_path:?},link file: {link_file_path:?}");
         let mut permission = file.metadata()?.permissions();
         permission.set_mode(permission.mode() | libc::S_ISUID | libc::S_ISGID);
         file.set_permissions(permission)
             .with_context(|| "failed to set permission")?;
 
         symlink(original_file_path, link_file_path)?;
-        println!("symlink success");
         Ok(())
     });
 
@@ -598,7 +596,6 @@ fn check_recursive_rsymfollow() -> TestResult {
             .with_context(|| "failed to set permission")?;
 
         symlink(original_file_path, link_file_path)?;
-        println!("symlink success");
         Ok(())
     });
 

--- a/tests/contest/runtimetest/src/utils.rs
+++ b/tests/contest/runtimetest/src/utils.rs
@@ -121,11 +121,9 @@ pub fn test_file_executable(path: &str) -> Result<(), std::io::Error> {
 }
 
 pub fn test_dir_update_access_time(path: &str) -> Result<(), std::io::Error> {
-    println!("test_dir_update_access_time path: {path:?}");
     let metadata = fs::metadata(PathBuf::from(path))?;
     let rest = metadata.accessed();
     let first_access_time = rest.unwrap();
-    println!("{path:?} dir first access time is {first_access_time:?}");
     // execute ls command to update access time
     Command::new("ls")
         .arg(path)
@@ -135,7 +133,6 @@ pub fn test_dir_update_access_time(path: &str) -> Result<(), std::io::Error> {
     let metadata = fs::metadata(PathBuf::from(path))?;
     let rest = metadata.accessed();
     let second_access_time = rest.unwrap();
-    println!("{path:?} dir second access time is {second_access_time:?}");
     if first_access_time == second_access_time {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -146,11 +143,9 @@ pub fn test_dir_update_access_time(path: &str) -> Result<(), std::io::Error> {
 }
 
 pub fn test_dir_not_update_access_time(path: &str) -> Result<(), std::io::Error> {
-    println!("test_dir_not_update_access_time path: {path:?}");
     let metadata = fs::metadata(PathBuf::from(path))?;
     let rest = metadata.accessed();
     let first_access_time = rest.unwrap();
-    println!("{path:?} dir first access time is {first_access_time:?}");
     // execute ls command to update access time
     Command::new("ls")
         .arg(path)
@@ -160,7 +155,6 @@ pub fn test_dir_not_update_access_time(path: &str) -> Result<(), std::io::Error>
     let metadata = fs::metadata(PathBuf::from(path))?;
     let rest = metadata.accessed();
     let second_access_time = rest.unwrap();
-    println!("{path:?} dir second access time is {second_access_time:?}");
     if first_access_time != second_access_time {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -171,7 +165,6 @@ pub fn test_dir_not_update_access_time(path: &str) -> Result<(), std::io::Error>
 }
 
 pub fn test_device_access(path: &str) -> Result<(), std::io::Error> {
-    println!("test_device_access path: {path:?}");
     let _ = std::fs::OpenOptions::new()
         .create(true)
         .truncate(true)
@@ -181,7 +174,6 @@ pub fn test_device_access(path: &str) -> Result<(), std::io::Error> {
 }
 
 pub fn test_device_unaccess(path: &str) -> Result<(), std::io::Error> {
-    println!("test_device_unaccess path: {path:?}");
     let _ = std::fs::OpenOptions::new()
         .create(true)
         .truncate(true)
@@ -206,13 +198,6 @@ pub fn test_mount_releatime_option(path: &str) -> Result<(), std::io::Error> {
         .arg(test_file_path.to_str().unwrap())
         .output()?;
     let one_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file one metadata atime is {:?},mtime is {:?},current time is{:?}",
-        test_file_path,
-        one_metadata.atime(),
-        one_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
     std::thread::sleep(std::time::Duration::from_millis(1000));
 
     // execute cat command to update access time
@@ -221,13 +206,6 @@ pub fn test_mount_releatime_option(path: &str) -> Result<(), std::io::Error> {
         .output()
         .expect("execute cat command error");
     let two_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file two metadata atime is {:?},mtime is {:?},current time is{:?}",
-        test_file_path,
-        two_metadata.atime(),
-        two_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
 
     if one_metadata.atime() == two_metadata.atime() {
         return Err(std::io::Error::new(
@@ -246,11 +224,6 @@ pub fn test_mount_releatime_option(path: &str) -> Result<(), std::io::Error> {
         .output()
         .expect("execute cat command error");
     let three_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file three metadata atime is {:?}",
-        test_file_path,
-        three_metadata.atime()
-    );
     if two_metadata.atime() != three_metadata.atime() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -271,13 +244,6 @@ pub fn test_mount_noreleatime_option(path: &str) -> Result<(), std::io::Error> {
         .arg(test_file_path.to_str().unwrap())
         .output()?;
     let one_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file one atime is {:?},mtime is {:?}, current time is {:?}",
-        test_file_path,
-        one_metadata.atime(),
-        one_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
 
     std::thread::sleep(std::time::Duration::from_millis(1000));
     // execute cat command to update access time
@@ -286,13 +252,6 @@ pub fn test_mount_noreleatime_option(path: &str) -> Result<(), std::io::Error> {
         .output()
         .expect("execute cat command error");
     let two_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file two atime is {:?},mtime is {:?},current time is {:?}",
-        test_file_path,
-        two_metadata.atime(),
-        two_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
 
     if one_metadata.atime() == two_metadata.atime() {
         return Err(std::io::Error::new(
@@ -311,13 +270,6 @@ pub fn test_mount_noreleatime_option(path: &str) -> Result<(), std::io::Error> {
         .output()
         .expect("execute cat command error");
     let three_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file three atime is {:?},mtime is {:?},current time is {:?}",
-        test_file_path,
-        three_metadata.atime(),
-        three_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
 
     if two_metadata.atime() != three_metadata.atime() {
         return Err(std::io::Error::new(
@@ -338,13 +290,7 @@ pub fn test_mount_rnoatime_option(path: &str) -> Result<(), std::io::Error> {
         .arg(test_file_path.to_str().unwrap())
         .output()?;
     let one_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file one atime is {:?},mtime is {:?}, current time is {:?}",
-        test_file_path,
-        one_metadata.atime(),
-        one_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
+
     std::thread::sleep(std::time::Duration::from_millis(1000));
 
     // execute cat command to update access time
@@ -353,13 +299,7 @@ pub fn test_mount_rnoatime_option(path: &str) -> Result<(), std::io::Error> {
         .output()
         .expect("execute cat command error");
     let two_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file two atime is {:?},mtime is {:?},current time is {:?}",
-        test_file_path,
-        two_metadata.atime(),
-        two_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
+
     if one_metadata.atime() != two_metadata.atime() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -379,13 +319,6 @@ pub fn test_mount_rstrictatime_option(path: &str) -> Result<(), std::io::Error> 
         .arg(test_file_path.to_str().unwrap())
         .output()?;
     let one_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file one atime is {:?},mtime is {:?}, current time is {:?}",
-        test_file_path,
-        one_metadata.atime(),
-        one_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
 
     std::thread::sleep(std::time::Duration::from_millis(1000));
     // execute cat command to update access time
@@ -394,13 +327,6 @@ pub fn test_mount_rstrictatime_option(path: &str) -> Result<(), std::io::Error> 
         .output()
         .expect("execute cat command error");
     let two_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file two atime is {:?},mtime is {:?},current time is {:?}",
-        test_file_path,
-        two_metadata.atime(),
-        two_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
 
     if one_metadata.atime() == two_metadata.atime() {
         return Err(std::io::Error::new(
@@ -419,13 +345,6 @@ pub fn test_mount_rstrictatime_option(path: &str) -> Result<(), std::io::Error> 
         .output()
         .expect("execute cat command error");
     let three_metadata = fs::metadata(test_file_path.clone())?;
-    println!(
-        "{:?} file three atime is {:?},mtime is {:?},current time is {:?}",
-        test_file_path,
-        two_metadata.atime(),
-        two_metadata.mtime(),
-        std::time::SystemTime::now()
-    );
 
     if two_metadata.atime() == three_metadata.atime() {
         return Err(std::io::Error::new(
@@ -492,7 +411,7 @@ pub fn test_mount_rsuid_option(path: &str) -> Result<(), std::io::Error> {
     // check suid and sgid
     let suid = metadata.mode() & 0o4000 == 0o4000;
     let sgid = metadata.mode() & 0o2000 == 0o2000;
-    println!("suid: {suid:?},sgid: {sgid:?}");
+
     if suid && sgid {
         return Ok(());
     }


### PR DESCRIPTION
## Description
This cleans up the logs printed by the contest tests when running. Originally there were several debug-type logs in format of println, however I think in tests, we should only have the error logs indicating the failure. If someone is working on tests, they can add debug logs as they like, but remove before merge. This makes the failure o/p clear to understand when any test fails. Right now, the actual failure logs are mixed up with the debug logs, making it harder to pinpoint failing test.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues


## Additional Context
There is also an issue with ns_itype_test where the tempdir it creates is not removed because it mounts it to actual root (expected behavior). This is same with runc, so still working on fixing it ; but opened this in meantime. 
