### PR TITLE
add a system call mock for uid/gid.

### DIFF
--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -576,7 +576,7 @@ impl Syscall for LinuxSyscall {
 
         if result.is_null() {
             // There is no such user, or an error has occurred.
-            // errno gets set if there’s an error.
+            // errno gets set if there's an error.
             return None;
         }
 
@@ -726,6 +726,22 @@ impl Syscall for LinuxSyscall {
     fn umount2(&self, target: &Path, flags: MntFlags) -> Result<()> {
         umount2(target, flags)?;
         Ok(())
+    }
+
+    fn get_uid(&self) -> Uid {
+        nix::unistd::getuid()
+    }
+
+    fn get_gid(&self) -> Gid {
+        nix::unistd::getgid()
+    }
+
+    fn get_euid(&self) -> Uid {
+        nix::unistd::geteuid()
+    }
+
+    fn get_egid(&self) -> Gid {
+        nix::unistd::getegid()
     }
 }
 

--- a/crates/libcontainer/src/syscall/syscall.rs
+++ b/crates/libcontainer/src/syscall/syscall.rs
@@ -55,6 +55,10 @@ pub trait Syscall {
     ) -> Result<()>;
     fn set_io_priority(&self, class: i64, priority: i64) -> Result<()>;
     fn umount2(&self, target: &Path, flags: MntFlags) -> Result<()>;
+    fn get_uid(&self) -> Uid;
+    fn get_gid(&self) -> Gid;
+    fn get_euid(&self) -> Uid;
+    fn get_egid(&self) -> Gid;
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Add a system call mock for uid, gid. euid, egid, etc.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3136 


## Additional Context
<!-- Add any other context about the pull request here -->
This change is related to the issue discussed in [this comment](https://github.com/youki-dev/youki/pull/3163#issuecomment-2891743532).
I have moved the `get` operations for `uid`, `gid`, `euid`, and `egid` used in the `libcontainer` and `youki` crates into the `syscall` package. As for `libcgroup` and `runtimetest`, they are not dependent on `libcontainer`, so they are omitted.