### PR TITLE
fix: youki does not conform with OCI runtime spec 

### DIFF
--- a/crates/libcgroups/src/systemd/cpu.rs
+++ b/crates/libcgroups/src/systemd/cpu.rs
@@ -42,7 +42,12 @@ impl Cpu {
         properties: &mut HashMap<&str, Variant>,
     ) -> Result<(), SystemdCpuError> {
         if Self::is_realtime_requested(cpu) {
-            return Err(SystemdCpuError::RealtimeSystemd);
+            let realtime_runtime = cpu.realtime_runtime();
+            let runtime_period = cpu.realtime_period();
+
+            if !matches!((realtime_runtime, runtime_period), (Some(0), Some(0))) {
+                return Err(SystemdCpuError::RealtimeSystemd);
+            }
         }
 
         if let Some(mut shares) = cpu.shares() {

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -86,7 +86,12 @@ impl StatsProvider for Cpu {
 impl Cpu {
     fn apply(path: &Path, cpu: &LinuxCpu) -> Result<(), V2CpuControllerError> {
         if Self::is_realtime_requested(cpu) {
-            return Err(V2CpuControllerError::RealtimeV2);
+            let realtime_runtime = cpu.realtime_runtime();
+            let runtime_period = cpu.realtime_period();
+
+            if !matches!((realtime_runtime, runtime_period), (Some(0), Some(0))) {
+                return Err(V2CpuControllerError::RealtimeV2);
+            }
         }
 
         if let Some(mut shares) = cpu.shares() {

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -97,16 +97,6 @@ impl ContainerBuilderImpl {
             .as_ref()
             .ok_or(MissingSpecError::Process)?;
 
-        if matches!(self.container_type, ContainerType::InitContainer) {
-            if let Some(hooks) = self.spec.hooks() {
-                hooks::run_hooks(
-                    hooks.create_runtime().as_ref(),
-                    self.container.as_ref(),
-                    None,
-                )?
-            }
-        }
-
         // Need to create the notify socket before we pivot root, since the unix
         // domain socket used here is outside of the rootfs of container. During
         // exec, need to create the socket before we enter into existing mount
@@ -201,6 +191,16 @@ impl ContainerBuilderImpl {
                 .set_pid(init_pid.as_raw())
                 .set_clean_up_intel_rdt_directory(need_to_clean_up_intel_rdt_dir)
                 .save()?;
+        }
+
+        if matches!(self.container_type, ContainerType::InitContainer) {
+            if let Some(hooks) = self.spec.hooks() {
+                hooks::run_hooks(
+                    hooks.create_runtime().as_ref(),
+                    self.container.as_ref(),
+                    None,
+                )?
+            }
         }
 
         Ok(init_pid)


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Hello, there was two issues here with nerdctl. The first one was the one described in the initial issue, which I fixed.

The second one had to do with nerdctl setting both `linux.resources.cpu.realtimeRuntime` and `linux.resources.cpu.realtimePeriod` to zero in the config.json despite youki trying to use cgroupsv2. This would cause a `V2CpuControllerError` to be thrown when the container is being created.

What I did is just check if cgroups2 is being used, and those two are set, if they are both set to zero then just continue as normal.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [X] Tested manually (please provide steps)
I was able to run an alpine image using nerdctl and containerd after applying the fixes.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #2994 

## Additional Context
<!-- Add any other context about the pull request here -->
N/A