### PR TITLE
fix: Ignoring CPU realtime on cgroupsv2 if set to zero

### DIFF
--- a/crates/libcgroups/src/systemd/cpu.rs
+++ b/crates/libcgroups/src/systemd/cpu.rs
@@ -45,7 +45,10 @@ impl Cpu {
             let realtime_runtime = cpu.realtime_runtime();
             let runtime_period = cpu.realtime_period();
 
-            if !matches!((realtime_runtime, runtime_period), (Some(0), Some(0))) {
+            let realtime_is_zero = realtime_runtime.is_none() || realtime_runtime.unwrap() == 0;
+            let period_is_zero = runtime_period.is_none() || runtime_period.unwrap() == 0;
+
+            if !realtime_is_zero && !period_is_zero {
                 return Err(SystemdCpuError::RealtimeSystemd);
             }
         }

--- a/crates/libcgroups/src/systemd/cpu.rs
+++ b/crates/libcgroups/src/systemd/cpu.rs
@@ -42,7 +42,12 @@ impl Cpu {
         properties: &mut HashMap<&str, Variant>,
     ) -> Result<(), SystemdCpuError> {
         if Self::is_realtime_requested(cpu) {
-            return Err(SystemdCpuError::RealtimeSystemd);
+            let realtime_runtime = cpu.realtime_runtime();
+            let runtime_period = cpu.realtime_period();
+
+            if !matches!((realtime_runtime, runtime_period), (Some(0), Some(0))) {
+                return Err(SystemdCpuError::RealtimeSystemd);
+            }
         }
 
         if let Some(mut shares) = cpu.shares() {

--- a/crates/libcgroups/src/systemd/cpu.rs
+++ b/crates/libcgroups/src/systemd/cpu.rs
@@ -42,13 +42,10 @@ impl Cpu {
         properties: &mut HashMap<&str, Variant>,
     ) -> Result<(), SystemdCpuError> {
         if Self::is_realtime_requested(cpu) {
-            let realtime_runtime = cpu.realtime_runtime();
-            let runtime_period = cpu.realtime_period();
+            let runtime = cpu.realtime_runtime().unwrap_or(0);
+            let period = cpu.realtime_period().unwrap_or(0);
 
-            let realtime_is_zero = realtime_runtime.is_none() || realtime_runtime.unwrap() == 0;
-            let period_is_zero = runtime_period.is_none() || runtime_period.unwrap() == 0;
-
-            if !realtime_is_zero && !period_is_zero {
+            if runtime > 0 || period > 0 {
                 return Err(SystemdCpuError::RealtimeSystemd);
             }
         }

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -86,7 +86,12 @@ impl StatsProvider for Cpu {
 impl Cpu {
     fn apply(path: &Path, cpu: &LinuxCpu) -> Result<(), V2CpuControllerError> {
         if Self::is_realtime_requested(cpu) {
-            return Err(V2CpuControllerError::RealtimeV2);
+            let realtime_runtime = cpu.realtime_runtime();
+            let runtime_period = cpu.realtime_period();
+
+            if !matches!((realtime_runtime, runtime_period), (Some(0), Some(0))) {
+                return Err(V2CpuControllerError::RealtimeV2);
+            }
         }
 
         if let Some(mut shares) = cpu.shares() {

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -377,4 +377,36 @@ mod tests {
         let actual = fs::read_to_string(burst_file).expect("read burst file");
         assert_eq!(actual, expected.to_string());
     }
+
+    #[test]
+    fn test_cgroupsv2_but_runtime_set_to_zero() {
+        // arrange
+        let tmp = tempfile::tempdir().unwrap();
+        let cpu = LinuxCpuBuilder::default()
+            .realtime_runtime(0i64)
+            .build()
+            .unwrap();
+
+        // act
+        let result = Cpu::apply(tmp.path(), &cpu);
+
+        // assert
+        assert!(result.is_ok())
+    }
+
+    #[test]
+    fn test_cgroupsv2_but_period_set_to_zero() {
+        // arrange
+        let tmp = tempfile::tempdir().unwrap();
+        let cpu = LinuxCpuBuilder::default()
+            .realtime_period(0u64)
+            .build()
+            .unwrap();
+
+        // act
+        let result = Cpu::apply(tmp.path(), &cpu);
+
+        // assert
+        assert!(result.is_ok())
+    }
 }

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -86,13 +86,10 @@ impl StatsProvider for Cpu {
 impl Cpu {
     fn apply(path: &Path, cpu: &LinuxCpu) -> Result<(), V2CpuControllerError> {
         if Self::is_realtime_requested(cpu) {
-            let realtime_runtime = cpu.realtime_runtime();
-            let runtime_period = cpu.realtime_period();
+            let runtime = cpu.realtime_runtime().unwrap_or(0);
+            let period = cpu.realtime_period().unwrap_or(0);
 
-            let realtime_is_zero = realtime_runtime.is_none() || realtime_runtime.unwrap() == 0;
-            let period_is_zero = runtime_period.is_none() || runtime_period.unwrap() == 0;
-
-            if !realtime_is_zero && !period_is_zero {
+            if runtime > 0 || period > 0 {
                 return Err(V2CpuControllerError::RealtimeV2);
             }
         }

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -89,7 +89,10 @@ impl Cpu {
             let realtime_runtime = cpu.realtime_runtime();
             let runtime_period = cpu.realtime_period();
 
-            if !matches!((realtime_runtime, runtime_period), (Some(0), Some(0))) {
+            let realtime_is_zero = realtime_runtime.is_none() || realtime_runtime.unwrap() == 0;
+            let period_is_zero = runtime_period.is_none() || runtime_period.unwrap() == 0;
+
+            if !realtime_is_zero && !period_is_zero {
                 return Err(V2CpuControllerError::RealtimeV2);
             }
         }

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -406,4 +406,21 @@ mod tests {
         // assert
         assert!(result.is_ok())
     }
+
+    #[test]
+    fn test_cgroupsv2_but_period_and_runtime_set_to_zero() {
+        // arrange
+        let tmp = tempfile::tempdir().unwrap();
+        let cpu = LinuxCpuBuilder::default()
+            .realtime_period(0u64)
+            .realtime_runtime(0i64)
+            .build()
+            .unwrap();
+
+        // act
+        let result = Cpu::apply(tmp.path(), &cpu);
+
+        // assert
+        assert!(result.is_ok())
+    }
 }


### PR DESCRIPTION
## Description
Requested to break up #3174 into two seperate issues by @YJDoc2.

This fixes an auxiliary issue of #2994, where `nerdctl` will set both `linux.resources.cpu.realtimeRuntime` and `linux.resources.cpu.realtimePeriod` to zero in the config.json despite youki trying to use cgroupsv2. This would cause a V2CpuControllerError to be thrown when the container is being created.

My solution is just to ignore them if using cgroupsv2 and they are both set to zero.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [X] Added new unit tests
- [ ] Added new integration tests
- [X] Ran existing test suite
- [X] Tested manually (please provide steps)

Once the initial runtime spec was fixed, this was able to run with no problems on nerdctl.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes part of  #2994.

## Additional Context
<!-- Add any other context about the pull request here -->
