### PR TITLE
fix: Running create_runtime hook after container is set to created.

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -97,16 +97,6 @@ impl ContainerBuilderImpl {
             .as_ref()
             .ok_or(MissingSpecError::Process)?;
 
-        if matches!(self.container_type, ContainerType::InitContainer) {
-            if let Some(hooks) = self.spec.hooks() {
-                hooks::run_hooks(
-                    hooks.create_runtime().as_ref(),
-                    self.container.as_ref(),
-                    None,
-                )?
-            }
-        }
-
         // Need to create the notify socket before we pivot root, since the unix
         // domain socket used here is outside of the rootfs of container. During
         // exec, need to create the socket before we enter into existing mount
@@ -201,6 +191,16 @@ impl ContainerBuilderImpl {
                 .set_pid(init_pid.as_raw())
                 .set_clean_up_intel_rdt_directory(need_to_clean_up_intel_rdt_dir)
                 .save()?;
+        }
+
+        if matches!(self.container_type, ContainerType::InitContainer) {
+            if let Some(hooks) = self.spec.hooks() {
+                hooks::run_hooks(
+                    hooks.create_runtime().as_ref(),
+                    self.container.as_ref(),
+                    None,
+                )?
+            }
         }
 
         Ok(init_pid)


### PR DESCRIPTION
## Description
Requested to break up #3174 into two seperate issues by @YJDoc2.

This fixes what was outlined in #2994, however this needs to be merged with #3180 for youki to actually work on `nerdctl`

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [X] Ran existing test suite
- [ ] Tested manually (please provide steps)
Once merged with #3180, has no issue running on `nerdctl`, also has no issue running on `podman` or `docker` either.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #2994

## Additional Context
<!-- Add any other context about the pull request here -->
