### PR TITLE
fix: allow duplicate additionalGids

### DIFF
--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::{env, fs, mem};
@@ -712,9 +712,6 @@ fn set_supplementary_gids(
 
         let gids: Vec<Gid> = additional_gids
             .iter()
-            // this is to remove duplicate ids, so we behave similar to runc
-            .collect::<HashSet<_>>()
-            .into_iter()
             .map(|gid| Gid::from_raw(*gid))
             .collect();
 
@@ -1004,6 +1001,13 @@ mod tests {
                     ..Default::default()
                 }),
                 vec![Gid::from_raw(37), Gid::from_raw(38)],
+            ),
+            (
+                UserBuilder::default()
+                    .additional_gids(vec![33, 34, 34])
+                    .build()?,
+                None::<UserNamespaceConfig>,
+                vec![Gid::from_raw(33), Gid::from_raw(34), Gid::from_raw(34)],
             ),
         ];
         for (user, ns_config, want) in tests.into_iter() {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
In `runc` v1.3.0, the behavior has changed when specifying duplicate `additionalGids`.
To align with this change, we are updating the behavior of `additionalGids` handling in youki accordingly.

For more details, please refer to the following issue.
https://github.com/opencontainers/runc/issues/4769#issue-3084751469

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [x] Other (please describe):
compatibility with runc

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
