### PR TITLE
update runc ci to 1.3.1

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -92,9 +92,9 @@ jobs:
         run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
-      - name: Install runc 1.1.11
+      - name: Install runc 1.3.1
         run: |
-          wget -q https://github.com/opencontainers/runc/releases/download/v1.1.11/runc.amd64
+          wget -q https://github.com/opencontainers/runc/releases/download/v1.3.1/runc.amd64
           sudo mv runc.amd64 /usr/bin/runc
           sudo chmod 755 /usr/bin/runc
       - name: Build


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Per the discussion, I’ll bump the runc version in CI to v1.3.1. From what I’ve checked, CI also passes with v1.3.1.

https://github.com/youki-dev/youki/pull/3202#discussion_r2328670570

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Related # https://github.com/youki-dev/youki/issues/3199

Related PR: https://github.com/youki-dev/youki/pull/3202


## Additional Context
<!-- Add any other context about the pull request here -->
