### PR TITLE
Add mdbook binary to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,4 +47,8 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 rustup install nightly
 rustup component add rustfmt
 rustup component add clippy 
+
+# Install mdbook
+VERSION=$(curl -sSfL https://api.github.com/repos/rust-lang/mdBook/releases/latest | jq -r .tag_name)
+curl -sSfL https://github.com/rust-lang/mdBook/releases/download/$VERSION/mdbook-$VERSION-$(uname -m)-unknown-linux-musl.tar.gz | tar -xzvC /usr/bin/ mdbook
 EOF

--- a/docs/src/developer/documentation_mdbook.md
+++ b/docs/src/developer/documentation_mdbook.md
@@ -6,7 +6,8 @@ Please make sure that you update this documentation along with newly added featu
 
 Currently this documentation is hosted at [https://youki-dev.github.io/youki/](https://youki-dev.github.io/youki/), using GitHub pages. GitHub CI actions are used to automatically check if any files are changed in /docs on each push / PR merge to main branch, and if there are any changes, the mdbook is build and deployed to gh-pages. We use [https://github.com/peaceiris/actions-mdbook](https://github.com/peaceiris/actions-mdbook) to build and then [https://github.com/peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) GitHub action to deploy the mdbook.
 
-When testing locally you can manually test the changes by running `mdbook serve` in the docs directory (after installing mdbook), which will temporarily serve the mdbook at `localhost:3000` by default. You can check the mdbook documentation for more information.
+When testing locally you can manually test the changes by running `mdbook serve` in the docs directory (after installing mdbook), which will temporarily serve the mdbook at `localhost:3000` by default. You can check the mdbook documentation for more information.  
+(If you are running inside a Dev Container, use `mdbook serve -n 0.0.0.0` instead)
 
 If you want to test it using gh-pages on your own fork, you can use following steps in the docs directory.
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Add mdbook to devcontainer for local documentation build.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):


## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)
  1. Rebuild and open the devcontainer
  2. Run `mdbook serve -n 0.0.0.0`
  3. Access `http://localhost:3000` in a browser
  4. Confirm that the mdbook documentation is displayed

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
