### PR TITLE
Unskip runc tests after CI runc update 1.3.1

### DIFF
--- a/tests/contest/contest/src/tests/domainname/mod.rs
+++ b/tests/contest/contest/src/tests/domainname/mod.rs
@@ -1,8 +1,8 @@
 use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
-use test_framework::{ConditionalTest, TestGroup, TestResult};
+use test_framework::{Test, TestGroup, TestResult};
 
+use crate::utils::test_inside_container;
 use crate::utils::test_utils::CreateOptions;
-use crate::utils::{is_runtime_runc, test_inside_container};
 
 fn get_spec(domainname: &str) -> Spec {
     SpecBuilder::default()
@@ -27,11 +27,7 @@ fn set_domainname_test() -> TestResult {
 
 pub fn get_domainname_tests() -> TestGroup {
     let mut tg = TestGroup::new("domainname_test");
-    let set_domainname_test = ConditionalTest::new(
-        "set_domainname_test",
-        Box::new(|| !is_runtime_runc()),
-        Box::new(set_domainname_test),
-    );
+    let set_domainname_test = Test::new("set_domainname_test", Box::new(set_domainname_test));
     tg.add(vec![Box::new(set_domainname_test)]);
 
     tg

--- a/tests/contest/contest/src/tests/exec_cpu_affinity/exec_cpu_affinity_test.rs
+++ b/tests/contest/contest/src/tests/exec_cpu_affinity/exec_cpu_affinity_test.rs
@@ -4,9 +4,9 @@ use anyhow::{Context, Result, anyhow};
 use oci_spec::runtime::{ExecCPUAffinityBuilder, ProcessBuilder, Spec, SpecBuilder};
 use regex::Regex;
 use serde_json::{Value, json};
-use test_framework::{ConditionalTest, TestGroup, TestResult, test_result};
+use test_framework::{Test, TestGroup, TestResult, test_result};
 
-use crate::utils::{exec_container, is_runtime_runc, start_container, test_outside_container};
+use crate::utils::{exec_container, start_container, test_outside_container};
 
 fn create_spec(initial: Option<&str>, fin: Option<&str>) -> Result<Spec> {
     let mut builder = ExecCPUAffinityBuilder::default();
@@ -163,26 +163,19 @@ fn test_cpu_affinity_from_config_json() -> TestResult {
     })
 }
 
-// In runc, `exec_cpu_affinity` is introduced in version 1.3.0.
-// Since the current CI uses an older version of runc, `exec_cpu_affinity` is not available and the test will be skipped.
-// youki/.github/workflows/integration_tests_validation.yaml:95
-// https://github.com/opencontainers/runc/releases/tag/v1.3.0-rc.1
 pub fn get_exec_cpu_affinity_test() -> TestGroup {
     let mut exec_cpu_affinity_test_group = TestGroup::new("exec_cpu_affinity");
 
-    let test_cpu_affinity_only_initial_set_from_process_json = ConditionalTest::new(
+    let test_cpu_affinity_only_initial_set_from_process_json = Test::new(
         "test_cpu_affinity_only_initial_set_from_process_json",
-        Box::new(|| !is_runtime_runc()),
         Box::new(test_cpu_affinity_only_initial_set_from_process_json),
     );
-    let test_cpu_affinity_initial_and_final_set_from_process_json = ConditionalTest::new(
+    let test_cpu_affinity_initial_and_final_set_from_process_json = Test::new(
         "test_cpu_affinity_initial_and_final_set_from_process_json",
-        Box::new(|| !is_runtime_runc()),
         Box::new(test_cpu_affinity_initial_and_final_set_from_process_json),
     );
-    let test_cpu_affinity_from_config_json = ConditionalTest::new(
+    let test_cpu_affinity_from_config_json = Test::new(
         "test_cpu_affinity_from_config_json",
-        Box::new(|| !is_runtime_runc()),
         Box::new(test_cpu_affinity_from_config_json),
     );
     exec_cpu_affinity_test_group.add(vec![

--- a/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
+++ b/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
@@ -2,10 +2,10 @@ use anyhow::{Context, Result};
 use oci_spec::runtime::{
     IOPriorityClass, LinuxIOPriorityBuilder, ProcessBuilder, Spec, SpecBuilder,
 };
-use test_framework::{ConditionalTest, TestGroup, TestResult, test_result};
+use test_framework::{Test, TestGroup, TestResult, test_result};
 
+use crate::utils::test_inside_container;
 use crate::utils::test_utils::CreateOptions;
-use crate::utils::{is_runtime_runc, test_inside_container};
 
 fn create_spec(
     io_priority_class: IOPriorityClass,
@@ -62,19 +62,12 @@ fn io_priority_class_idle_test() -> TestResult {
 
 pub fn get_io_priority_test() -> TestGroup {
     let mut io_priority_group = TestGroup::new("set_io_priority");
-    let io_priority_class_rt = ConditionalTest::new(
-        "io_priority_class_rt",
-        Box::new(|| !is_runtime_runc()),
-        Box::new(io_priority_class_rt_test),
-    );
-    let io_priority_class_be = ConditionalTest::new(
-        "io_priority_class_be",
-        Box::new(|| !is_runtime_runc()),
-        Box::new(io_priority_class_be_test),
-    );
-    let io_priority_class_idle = ConditionalTest::new(
+    let io_priority_class_rt =
+        Test::new("io_priority_class_rt", Box::new(io_priority_class_rt_test));
+    let io_priority_class_be =
+        Test::new("io_priority_class_be", Box::new(io_priority_class_be_test));
+    let io_priority_class_idle = Test::new(
         "io_priority_class_idle",
-        Box::new(|| !is_runtime_runc()),
         Box::new(io_priority_class_idle_test),
     );
 

--- a/tests/contest/contest/src/tests/process_user/process_user_test.rs
+++ b/tests/contest/contest/src/tests/process_user/process_user_test.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Ok, Result};
 use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder, UserBuilder};
 use rand::Rng;
-use test_framework::{ConditionalTest, TestGroup, TestResult, test_result};
+use test_framework::{Test, TestGroup, TestResult, test_result};
 
+use crate::utils::test_inside_container;
 use crate::utils::test_utils::CreateOptions;
-use crate::utils::{is_runtime_runc, test_inside_container};
 
 // Generates a Vec<u32> with a random number of elements (between 5 and 15),
 // where each element is a random u32 value between 0 and 65535.
@@ -60,16 +60,12 @@ fn process_user_test_duplicate_gids() -> TestResult {
 pub fn get_process_user_test() -> TestGroup {
     let mut process_user_test_group = TestGroup::new("process_user");
 
-    let test1 = ConditionalTest::new(
+    let test1 = Test::new(
         "process_user_unique_gids_test",
-        Box::new(|| true),
         Box::new(process_user_test_unique_gids),
     );
-    // In runc 1.1, duplicates are removed, but in 1.3, duplicates are handled as-is.
-    // The current CI for Youki uses runc 1.1, so this will be skipped.
-    let test2 = ConditionalTest::new(
+    let test2 = Test::new(
         "process_user_duplicate_gids_test",
-        Box::new(|| !is_runtime_runc()),
         Box::new(process_user_test_duplicate_gids),
     );
     process_user_test_group.add(vec![Box::new(test1), Box::new(test2)]);

--- a/tests/contest/contest/src/tests/rootfs_propagation/rootfs_propagation_test.rs
+++ b/tests/contest/contest/src/tests/rootfs_propagation/rootfs_propagation_test.rs
@@ -3,10 +3,10 @@ use oci_spec::runtime::{
     Capability, LinuxBuilder, LinuxCapabilitiesBuilder, LinuxSeccompBuilder, ProcessBuilder,
     RootBuilder, Spec, SpecBuilder,
 };
-use test_framework::{ConditionalTest, TestGroup, TestResult, test_result};
+use test_framework::{Test, TestGroup, TestResult, test_result};
 
+use crate::utils::test_inside_container;
 use crate::utils::test_utils::CreateOptions;
-use crate::utils::{is_runtime_runc, test_inside_container};
 
 fn create_spec(propagation: String) -> Result<Spec> {
     let root = RootBuilder::default()
@@ -75,24 +75,20 @@ fn rootfs_propagation_unbindable_test() -> TestResult {
 pub fn get_rootfs_propagation_test() -> TestGroup {
     let mut rootfs_propagation_test_group = TestGroup::new("rootfs_propagation");
 
-    let rootfs_propagation_shared_test = ConditionalTest::new(
+    let rootfs_propagation_shared_test = Test::new(
         "rootfs_propagation_shared_test",
-        Box::new(|| !is_runtime_runc()),
         Box::new(rootfs_propagation_shared_test),
     );
-    let rootfs_propagation_slave_test = ConditionalTest::new(
+    let rootfs_propagation_slave_test = Test::new(
         "rootfs_propagation_slave_test",
-        Box::new(|| true),
         Box::new(rootfs_propagation_slave_test),
     );
-    let rootfs_propagation_private_test = ConditionalTest::new(
+    let rootfs_propagation_private_test = Test::new(
         "rootfs_propagation_private_test",
-        Box::new(|| true),
         Box::new(rootfs_propagation_private_test),
     );
-    let rootfs_propagation_unbindable_test = ConditionalTest::new(
+    let rootfs_propagation_unbindable_test = Test::new(
         "rootfs_propagation_unbindable_test",
-        Box::new(|| !is_runtime_runc()),
         Box::new(rootfs_propagation_unbindable_test),
     );
     rootfs_propagation_test_group.add(vec![

--- a/tests/contest/contest/src/tests/scheduler/scheduler_policy.rs
+++ b/tests/contest/contest/src/tests/scheduler/scheduler_policy.rs
@@ -2,10 +2,10 @@ use anyhow::{Context, Result};
 use oci_spec::runtime::{
     LinuxSchedulerPolicy, ProcessBuilder, SchedulerBuilder, Spec, SpecBuilder,
 };
-use test_framework::{ConditionalTest, TestGroup, TestResult, test_result};
+use test_framework::{Test, TestGroup, TestResult, test_result};
 
+use crate::utils::test_inside_container;
 use crate::utils::test_utils::CreateOptions;
-use crate::utils::{is_runtime_runc, test_inside_container};
 
 fn create_spec(policy: LinuxSchedulerPolicy, execute_test: &str) -> Result<Spec> {
     let sc = SchedulerBuilder::default()
@@ -47,16 +47,8 @@ fn scheduler_policy_batch_test() -> TestResult {
 
 pub fn get_scheduler_test() -> TestGroup {
     let mut scheduler_policy_group = TestGroup::new("set_scheduler_policy");
-    let policy_fifo_test = ConditionalTest::new(
-        "policy_other",
-        Box::new(|| !is_runtime_runc()),
-        Box::new(scheduler_policy_other_test),
-    );
-    let policy_rr_test = ConditionalTest::new(
-        "policy_batch",
-        Box::new(|| !is_runtime_runc()),
-        Box::new(scheduler_policy_batch_test),
-    );
+    let policy_fifo_test = Test::new("policy_other", Box::new(scheduler_policy_other_test));
+    let policy_rr_test = Test::new("policy_batch", Box::new(scheduler_policy_batch_test));
 
     scheduler_policy_group.add(vec![Box::new(policy_fifo_test), Box::new(policy_rr_test)]);
     scheduler_policy_group


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
The following tests had been skipped because the runc version used in CI was `1.1.11`. 
The runc version was updated in the commit below. 
https://github.com/youki-dev/youki/pull/3237

Therefore, I am removing the `is_runtime_runc` handling from the tests that now pass:

* domainname
* exec_cpu_affinity
* io_priority
* process_user
* rootfs_propagation
* scheduler_policy

(Since the `fd_control` tests still appear to fail on runc, we’ll keep them as-is for now.)

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes https://github.com/youki-dev/youki/issues/3141

## Additional Context
<!-- Add any other context about the pull request here -->

The referenced issue concerns the failure of the `rootfs_propagation` test. It will be resolved once this PR is merged.
