### PR TITLE
Fix podman ci

### DIFF
--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install skopeo and podman requirements
         run: |
           sudo apt-get install -y pkg-config libsystemd-dev libelf-dev libseccomp-dev libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev bats socat protobuf-compiler jq conmon
-          cargo install netavark aardvark-dns
+          cargo install netavark aardvark-dns --locked
       
       - name: Copy binaries
         run: |


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

I’m going to fix the Podman CI.

Most recently, it seems to be failing when running `cargo install netavark aardvark-dns` due to dependency issues. 
https://github.com/youki-dev/youki/actions/workflows/podman_tests.yaml

According to the Rust documentation, `cargo install` does not use `Cargo.lock` by default; adding the `--locked` option makes it respect the `Cargo.lock` file.

ref: https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile



## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

I ran Podman’s CI in my own repository, and it succeeded.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
