### PR TITLE
feat(libcgroups): Support sub-cgroups for unified systemd cgroup manager

### DIFF
--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -201,7 +201,8 @@ impl Manager {
         let mut destructured_path: CgroupsPath = cgroups_path.as_path().try_into()?;
         ensure_parent_unit(&mut destructured_path, use_system);
 
-        let sub_cgroup = Self::extract_sub_cgroup(&mut destructured_path.name);
+        let (name, sub_cgroup) = Self::extract_sub_cgroup(&destructured_path.name);
+        destructured_path.name = name;
 
         // EAGAIN from a recv() that timed out via SO_RCVTIMEO (set in dbus::connect()).
         let is_eagain = |e: &SystemdManagerError| {
@@ -316,16 +317,20 @@ impl Manager {
     }
 
     // If the provided unit `name` contains a sub-cgroup suffix, split it off and
-    // return that suffix as a separate cgroup path.
-    // The original `name` is mutated in-place to keep only the base unit name.
+    // return it as a separate cgroup path along with the base unit name.
     //
     // Example: "{id}/sub/init" becomes:
-    //   - name: "{id}"
-    //   - returned sub-cgroup: "/sub/init"
-    fn extract_sub_cgroup(name: &mut String) -> String {
-        name.find("/")
-            .map(|separator_index| name.split_off(separator_index))
-            .unwrap_or_default()
+    //   - base name: "{id}"
+    //   - sub-cgroup: "/sub/init"
+    fn extract_sub_cgroup(name: &str) -> (String, String) {
+        name.find('/')
+            .map(|separator_index| {
+                (
+                    name[..separator_index].to_owned(),
+                    name[separator_index..].to_owned(),
+                )
+            })
+            .unwrap_or_else(|| (name.to_owned(), String::new()))
     }
 
     /// get_unit_name returns the unit (scope) name from the path provided by the user
@@ -686,8 +691,7 @@ mod tests {
         ];
 
         for case in cases {
-            let mut name = case.name.to_owned();
-            let sub_cgroup = Manager::extract_sub_cgroup(&mut name);
+            let (name, sub_cgroup) = Manager::extract_sub_cgroup(case.name);
             assert_eq!(name, case.expected_name, "name mismatch for {}", case.name);
             assert_eq!(
                 sub_cgroup, case.expected_sub_cgroup,

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -506,8 +506,11 @@ impl CgroupManager for Manager {
         }
         if self.client.transient_unit_exists(&self.unit_name) {
             tracing::debug!("Transient unit {:?} already exists", self.unit_name);
-            self.client
-                .add_process_to_unit(&self.unit_name, "", pid.as_raw() as u32)?;
+            self.client.add_process_to_unit(
+                &self.unit_name,
+                &self.sub_cgroup,
+                pid.as_raw() as u32,
+            )?;
             return Ok(());
         }
 

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -310,6 +310,19 @@ impl Manager {
         .into())
     }
 
+    // If the provided unit `name` contains a sub-cgroup suffix, split it off and
+    // return that suffix as a separate cgroup path.
+    // The original `name` is mutated in-place to keep only the base unit name.
+    //
+    // Example: "{id}/sub/init" becomes:
+    //   - name: "{id}"
+    //   - returned sub-cgroup: "/sub/init"
+    fn extract_sub_cgroup(name: &mut String) -> String {
+        name.find("/")
+            .map(|separator_index| name.split_off(separator_index))
+            .unwrap_or_default()
+    }
+
     /// get_unit_name returns the unit (scope) name from the path provided by the user
     /// for example: foo:docker:bar returns in '/docker-bar.scope'
     fn get_unit_name(cgroups_path: &CgroupsPath) -> String {

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -343,6 +343,7 @@ impl Manager {
     fn construct_cgroups_path(
         cgroups_path: &CgroupsPath,
         client: &dyn SystemdClient,
+        sub_cgroup: &str,
     ) -> Result<(PathBuf, PathBuf), SystemdManagerError> {
         // if the user provided a '.slice' (as in a branch of a tree)
         // we need to convert it to a filesystem path.
@@ -351,7 +352,10 @@ impl Manager {
         let systemd_root = client.control_cgroup_root()?;
         let unit_name = Self::get_unit_name(cgroups_path);
 
-        let cgroups_path = systemd_root.join_safely(parent)?.join_safely(unit_name)?;
+        let cgroups_path = systemd_root
+            .join_safely(parent)?
+            .join_safely(unit_name)?
+            .join_safely(sub_cgroup)?;
         Ok((cgroups_path, systemd_root))
     }
 

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -201,8 +201,9 @@ impl Manager {
         let mut destructured_path: CgroupsPath = cgroups_path.as_path().try_into()?;
         ensure_parent_unit(&mut destructured_path, use_system);
 
-        let (name, sub_cgroup) = Self::extract_sub_cgroup(&destructured_path.name);
-        destructured_path.name = name;
+        let (name, sub_cgroup) = Self::split_sub_cgroup(&destructured_path.name);
+        let sub_cgroup = sub_cgroup.to_owned();
+        destructured_path.name = name.to_owned();
 
         // EAGAIN from a recv() that timed out via SO_RCVTIMEO (set in dbus::connect()).
         let is_eagain = |e: &SystemdManagerError| {
@@ -316,21 +317,16 @@ impl Manager {
         .into())
     }
 
-    // If the provided unit `name` contains a sub-cgroup suffix, split it off and
-    // return it as a separate cgroup path along with the base unit name.
-    //
+    // split_sub_cgroup splits the unit `name` into the base unit name and the
+    // sub-cgroup suffix.
     // Example: "{id}/sub/init" becomes:
     //   - base name: "{id}"
     //   - sub-cgroup: "/sub/init"
-    fn extract_sub_cgroup(name: &str) -> (String, String) {
-        name.find('/')
-            .map(|separator_index| {
-                (
-                    name[..separator_index].to_owned(),
-                    name[separator_index..].to_owned(),
-                )
-            })
-            .unwrap_or_else(|| (name.to_owned(), String::new()))
+    fn split_sub_cgroup(name: &str) -> (&str, &str) {
+        match name.find('/') {
+            Some(i) => name.split_at(i),
+            None => (name, ""),
+        }
     }
 
     /// get_unit_name returns the unit (scope) name from the path provided by the user
@@ -661,7 +657,7 @@ mod tests {
     }
 
     #[test]
-    fn test_separate_sub_cgroup() {
+    fn test_split_sub_cgroup() {
         struct Case {
             name: &'static str,
             expected_name: &'static str,
@@ -691,7 +687,7 @@ mod tests {
         ];
 
         for case in cases {
-            let (name, sub_cgroup) = Manager::extract_sub_cgroup(case.name);
+            let (name, sub_cgroup) = Manager::split_sub_cgroup(case.name);
             assert_eq!(name, case.expected_name, "name mismatch for {}", case.name);
             assert_eq!(
                 sub_cgroup, case.expected_sub_cgroup,

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -201,6 +201,8 @@ impl Manager {
         let mut destructured_path: CgroupsPath = cgroups_path.as_path().try_into()?;
         ensure_parent_unit(&mut destructured_path, use_system);
 
+        let sub_cgroup = Self::extract_sub_cgroup(&mut destructured_path.name);
+
         // EAGAIN from a recv() that timed out via SO_RCVTIMEO (set in dbus::connect()).
         let is_eagain = |e: &SystemdManagerError| {
             matches!(
@@ -262,7 +264,6 @@ impl Manager {
 
             // Step 2 — initial method calls to discover the cgroup path.
             // On EAGAIN, client is dropped here and the next iteration reconnects.
-            let sub_cgroup = Self::extract_sub_cgroup(&mut destructured_path.name);
             match Self::construct_cgroups_path(&destructured_path, &client, &sub_cgroup) {
                 Ok((cgroups_path, delegation_boundary)) => {
                     let full_path = root_path.join_safely(&cgroups_path)?;

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -644,6 +644,48 @@ mod tests {
     }
 
     #[test]
+    fn test_separate_sub_cgroup() {
+        struct Case {
+            name: &'static str,
+            expected_name: &'static str,
+            expected_sub_cgroup: &'static str,
+        }
+        let cases = [
+            Case {
+                name: "youki-569d5ce3afe1074769f67",
+                expected_name: "youki-569d5ce3afe1074769f67",
+                expected_sub_cgroup: "",
+            },
+            Case {
+                name: "youki-569d5ce3afe1074769f67/init",
+                expected_name: "youki-569d5ce3afe1074769f67",
+                expected_sub_cgroup: "/init",
+            },
+            Case {
+                name: "youki-569d5ce3afe1074769f67/sub/init",
+                expected_name: "youki-569d5ce3afe1074769f67",
+                expected_sub_cgroup: "/sub/init",
+            },
+            Case {
+                name: "youki-569d5ce3afe1074769f67/",
+                expected_name: "youki-569d5ce3afe1074769f67",
+                expected_sub_cgroup: "/",
+            },
+        ];
+
+        for case in cases {
+            let mut name = case.name.to_owned();
+            let sub_cgroup = Manager::extract_sub_cgroup(&mut name);
+            assert_eq!(name, case.expected_name, "name mismatch for {}", case.name);
+            assert_eq!(
+                sub_cgroup, case.expected_sub_cgroup,
+                "sub_cgroup mismatch for {}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
     fn expand_slice_works() -> Result<()> {
         assert_eq!(
             Manager::expand_slice("test-a-b.slice")?,

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -48,6 +48,8 @@ pub struct Manager {
     destructured_path: CgroupsPath,
     /// Name of the container e.g. 569d5ce3afe1074769f67
     container_name: String,
+    /// Name of the sub-cgroup
+    sub_cgroup: String,
     /// Name of the systemd unit e.g. youki-569d5ce3afe1074769f67.scope
     unit_name: String,
     /// Client for communicating with systemd
@@ -260,7 +262,8 @@ impl Manager {
 
             // Step 2 — initial method calls to discover the cgroup path.
             // On EAGAIN, client is dropped here and the next iteration reconnects.
-            match Self::construct_cgroups_path(&destructured_path, &client) {
+            let sub_cgroup = Self::extract_sub_cgroup(&mut destructured_path.name);
+            match Self::construct_cgroups_path(&destructured_path, &client, &sub_cgroup) {
                 Ok((cgroups_path, delegation_boundary)) => {
                     let full_path = root_path.join_safely(&cgroups_path)?;
                     let fs_manager = FsManager::new(root_path.clone(), cgroups_path.clone())?;
@@ -270,6 +273,7 @@ impl Manager {
                         full_path,
                         container_name,
                         unit_name: Self::get_unit_name(&destructured_path),
+                        sub_cgroup,
                         destructured_path,
                         client,
                         fs_manager,

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -713,7 +713,7 @@ mod tests {
             .context("construct path")?;
 
         assert_eq!(
-            Manager::construct_cgroups_path(&cgroups_path, &TestSystemdClient {})?.0,
+            Manager::construct_cgroups_path(&cgroups_path, &TestSystemdClient {}, "")?.0,
             PathBuf::from("/test.slice/test-a.slice/test-a-b.slice/docker-foo.scope"),
         );
 
@@ -727,8 +727,22 @@ mod tests {
             .context("construct path")?;
 
         assert_eq!(
-            Manager::construct_cgroups_path(&cgroups_path, &TestSystemdClient {})?.0,
+            Manager::construct_cgroups_path(&cgroups_path, &TestSystemdClient {}, "")?.0,
             PathBuf::from("/machine.slice/libpod-foo.scope"),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_cgroups_path_works_with_sub_cgroup() -> Result<()> {
+        let cgroups_path = Path::new("machine.slice:libpod:foo")
+            .try_into()
+            .context("construct path")?;
+
+        assert_eq!(
+            Manager::construct_cgroups_path(&cgroups_path, &TestSystemdClient {}, "/init")?.0,
+            PathBuf::from("/machine.slice/libpod-foo.scope/init"),
         );
 
         Ok(())
@@ -742,7 +756,7 @@ mod tests {
         ensure_parent_unit(&mut cgroups_path, true);
 
         assert_eq!(
-            Manager::construct_cgroups_path(&cgroups_path, &TestSystemdClient {})?.0,
+            Manager::construct_cgroups_path(&cgroups_path, &TestSystemdClient {}, "")?.0,
             PathBuf::from("/system.slice/docker-foo.scope"),
         );
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Adds support for sub-cgroups in the unified systemd cgroup manager.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
fixes #3565 
refs #3342
refs #3347
dependent #3564 

## Additional Context
<!-- Add any other context about the pull request here -->
https://github.com/youki-dev/youki/pull/3347#issuecomment-4557200770