### PR TITLE
fix(libcontainer): Join a tenant container to the landlord init process’s sub-cgroup when applicable

### DIFF
--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -137,6 +137,7 @@ fn get_capabilities(
 
 // Only works for cgroup v2
 fn get_init_proc_sub_cgroup(container: &Container, spec: &Spec) -> Option<String> {
+    let container_id = container.id();
     let init_pid = container.pid()?.as_raw() as u32;
 
     let init_proc_cgroups = (|| -> Result<ProcessCGroups, Box<dyn std::error::Error>> {
@@ -146,9 +147,13 @@ fn get_init_proc_sub_cgroup(container: &Container, spec: &Spec) -> Option<String
             OpenFlags::O_RDONLY | OpenFlags::O_CLOEXEC,
         )?)?)
     })()
+    .map_err(|e| {
+        tracing::debug!("failed to get cgroup for init process of container {container_id}: {e} ");
+        e
+    })
     .ok()?;
 
-    infer_sub_cgroup_from_proc_cgroups(&init_proc_cgroups, container.id(), spec)
+    infer_sub_cgroup_from_proc_cgroups(&init_proc_cgroups, container_id, spec)
 }
 
 fn infer_sub_cgroup_from_proc_cgroups(

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -813,6 +813,88 @@ mod tests {
         Ok(())
     }
 
+    // --- infer sub-cgroup tests ---
+
+    fn get_spec_with_cgroup_path(cgroups_path: Option<PathBuf>) -> Spec {
+        let linux = cgroups_path
+            .into_iter()
+            .fold(LinuxBuilder::default(), |builder, cgroups_path| {
+                builder.cgroups_path(cgroups_path)
+            })
+            .build()
+            .unwrap();
+
+        SpecBuilder::default().linux(linux).build().unwrap()
+    }
+
+    #[test]
+    fn test_infer_sub_cgroup_from_proc_cgroups() {
+        const CONTAINER_ID: &str = "569d5ce3afe1074769f67";
+
+        struct Case {
+            name: &'static str,
+            cgroups_path: Option<PathBuf>,
+            proc_path: String,
+            expected: Option<&'static str>,
+        }
+        let cases = [
+            Case {
+                name: "default cgroup path uses container id",
+                cgroups_path: None,
+                proc_path: format!("/youki-{CONTAINER_ID}.scope/init"),
+                expected: Some("init"),
+            },
+            Case {
+                name: "valid sub-cgroup for fs controller",
+                cgroups_path: Some(PathBuf::from(format!("/docker/{CONTAINER_ID}"))),
+                proc_path: format!("/docker/{CONTAINER_ID}/init"),
+                expected: Some("init"),
+            },
+            Case {
+                name: "valid sub-cgroup for domain controller",
+                cgroups_path: Some(PathBuf::from(format!("system.slice:docker:{CONTAINER_ID}"))),
+                proc_path: format!("/system.slice/docker-{CONTAINER_ID}.scope/init"),
+                expected: Some("init"),
+            },
+            Case {
+                name: "valid multi layer sub-cgroup",
+                cgroups_path: Some(PathBuf::from(format!("system.slice:docker:{CONTAINER_ID}"))),
+                proc_path: format!("/system.slice/docker-{CONTAINER_ID}.scope/subgroup/init"),
+                expected: Some("subgroup/init"),
+            },
+            Case {
+                name: "cgroup path doesn't match proc path",
+                cgroups_path: Some(PathBuf::from(format!("/docker/{CONTAINER_ID}"))),
+                proc_path: "/docker/other-container/subgroup".to_string(),
+                expected: None,
+            },
+            Case {
+                name: "no sub-cgroup for fs controller",
+                cgroups_path: Some(PathBuf::from(format!("/docker/{CONTAINER_ID}"))),
+                proc_path: format!("/docker/{CONTAINER_ID}"),
+                expected: None,
+            },
+            Case {
+                name: "no sub-cgroup for domain controller",
+                cgroups_path: Some(PathBuf::from(format!("system.slice:docker:{CONTAINER_ID}"))),
+                proc_path: format!("/system.slice/docker-{CONTAINER_ID}.scope"),
+                expected: None,
+            },
+        ];
+
+        for case in cases {
+            let spec = get_spec_with_cgroup_path(case.cgroups_path);
+            let proc_cgroups = ProcessCGroups(vec![procfs::ProcessCGroup {
+                hierarchy: 0,
+                controllers: Vec::new(),
+                pathname: case.proc_path.to_string(),
+            }]);
+
+            let actual = infer_sub_cgroup_from_proc_cgroups(&proc_cgroups, CONTAINER_ID, &spec);
+            assert_eq!(actual.as_deref(), case.expected, "{}", case.name);
+        }
+    }
+
     // --- environment tests ---
 
     #[test]

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use caps::Capability;
+use libcgroups::common::CgroupSetup;
 use nix::fcntl::OFlag;
 use nix::unistd::{Pid, pipe2, read};
 use oci_spec::runtime::{
@@ -137,6 +138,11 @@ fn get_capabilities(
 
 // Only works for cgroup v2
 fn get_init_proc_sub_cgroup(container: &Container, spec: &Spec) -> Option<String> {
+    match libcgroups::common::get_cgroup_setup() {
+        Ok(CgroupSetup::Unified) => {}
+        Ok(_) | Err(_) => return None,
+    }
+
     let container_id = container.id();
     let init_pid = container.pid()?.as_raw() as u32;
 

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -16,7 +16,10 @@ use oci_spec::runtime::{
     LinuxCapabilities, LinuxCapabilitiesBuilder, LinuxNamespace, LinuxNamespaceBuilder,
     LinuxNamespaceType, Process, ProcessBuilder, Spec, UserBuilder,
 };
+use pathrs::flags::OpenFlags;
+use pathrs::procfs::{ProcfsBase, ProcfsHandle};
 use procfs::process::Namespace;
+use procfs::{FromRead, ProcessCGroups};
 
 use super::Container;
 use super::builder::ContainerBuilder;
@@ -130,6 +133,45 @@ fn get_capabilities(
     caps.set_inheritable(None);
     caps.set_ambient(None);
     Ok(caps)
+}
+
+// Only works for cgroup v2
+fn get_init_proc_sub_cgroup(container: &Container, spec: &Spec) -> Option<String> {
+    let init_pid = container.pid()?.as_raw() as u32;
+
+    let init_proc_cgroups = (|| -> Result<ProcessCGroups, Box<dyn std::error::Error>> {
+        Ok(ProcessCGroups::from_read(ProcfsHandle::new()?.open(
+            ProcfsBase::ProcPid(init_pid),
+            "cgroup",
+            OpenFlags::O_RDONLY | OpenFlags::O_CLOEXEC,
+        )?)?)
+    })()
+    .ok()?;
+
+    infer_sub_cgroup_from_proc_cgroups(&init_proc_cgroups, container.id(), spec)
+}
+
+fn infer_sub_cgroup_from_proc_cgroups(
+    init_proc_cgroups: &ProcessCGroups,
+    container_id: &str,
+    spec: &Spec,
+) -> Option<String> {
+    let init_proc_cgroup = init_proc_cgroups
+        .into_iter()
+        // get_sub_cgroup_of_container_init_proc() is necessary only in cgroup v2,
+        // where there is only a single cgroup with an empty controller name.
+        .find(|c| c.controllers.is_empty())?;
+
+    let original_cgroup =
+        utils::get_cgroup_path(spec.linux().as_ref()?.cgroups_path(), container_id);
+    let container_name = original_cgroup.file_name()?.to_str()?.split(":").last()?;
+
+    // Locate the container's cgroup segment and return the trailing sub-cgroup path.
+    let mut init_proc_cgroup_path_parts = init_proc_cgroup.pathname.split("/");
+    init_proc_cgroup_path_parts
+        .any(|part| part.contains(container_name))
+        .then(|| init_proc_cgroup_path_parts.collect::<Vec<_>>().join("/"))
+        .filter(|s| !s.is_empty())
 }
 
 impl TenantContainerBuilder {

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -305,6 +305,20 @@ impl TenantContainerBuilder {
         let (read_end, write_end) =
             pipe2(OFlag::O_CLOEXEC).map_err(LibcontainerError::OtherSyscall)?;
 
+        // In cgroup v2, joining a TenantContainer into a nested container's cgroup may fail
+        // with EBUSY due to the "no internal processes constraint".
+        // If no explicit sub-cgroup is provided, infer the sub-cgroup from the init process
+        // of the landlord and use that.
+        // For a normal landlord container, this remains None.
+        // Ref: https://github.com/youki-dev/youki/issues/3342
+        let sub_cgroup_path = match self.sub_cgroup {
+            Some(s) if !s.is_empty() => Some(s),
+            _ => get_init_proc_sub_cgroup(&container, &spec).map(|sub_cgroup| {
+                tracing::debug!("inferred sub-cgroup path from landlord container: {sub_cgroup}");
+                sub_cgroup
+            }),
+        };
+
         let mut builder_impl = ContainerBuilderImpl {
             container_type: ContainerType::TenantContainer {
                 exec_notify_fd: write_end.as_raw_fd(),
@@ -327,7 +341,7 @@ impl TenantContainerBuilder {
             stdout: self.base.stdout,
             stderr: self.base.stderr,
             as_sibling: self.as_sibling,
-            sub_cgroup_path: self.sub_cgroup,
+            sub_cgroup_path,
             process_label: self.process_label,
         };
 

--- a/tests/contest/contest/src/tests/exec/cgroup_test.rs
+++ b/tests/contest/contest/src/tests/exec/cgroup_test.rs
@@ -105,8 +105,14 @@ pub(crate) fn cgroup_test() -> TestResult {
         .expect("exec failed");
 
         // the init process is now in "/foo", but an exec process can still join "/" because we haven't enabled any domain controller yet
-        exec_container(id, dir, &["grep", "^0::/$", "/proc/self/cgroup"], None, &[])
-            .expect("exec failed");
+        exec_container(
+            id,
+            dir,
+            &["grep", "^0::/foobar$", "/proc/self/cgroup"],
+            None,
+            &[],
+        )
+        .expect("exec failed");
 
         // turn on a domain controller (memory)
         exec_container(
@@ -121,18 +127,19 @@ pub(crate) fn cgroup_test() -> TestResult {
         // TODO: Implement the test cases discussed in
         // https://github.com/youki-dev/youki/pull/3210#discussion_r2554961182.
         // This depends on changes introduced by PR https://github.com/youki-dev/youki/pull/3347.
-        // // an exec process can no longer join "/" after turning on a domain controller. Check that cgroup v2 fallback to init cgroup works
-        // exec_container(
-        //     id,
-        //     dir,
-        //     &[
-        //         "sh",
-        //         "-euc",
-        //         "cat /proc/self/cgroup && grep '^0::/foobar$' /proc/self/cgroup",
-        //     ],
-        //     None,
-        // )
-        // .expect("exec failed");
+        // an exec process can no longer join "/" after turning on a domain controller. Check that cgroup v2 fallback to init cgroup works
+        exec_container(
+            id,
+            dir,
+            &[
+                "sh",
+                "-euc",
+                "cat /proc/self/cgroup && grep '^0::/foobar$' /proc/self/cgroup",
+            ],
+            None,
+            &[],
+        )
+        .expect("exec failed");
 
         TestResult::Passed
     })

--- a/tests/contest/contest/src/tests/exec/cgroup_test.rs
+++ b/tests/contest/contest/src/tests/exec/cgroup_test.rs
@@ -94,6 +94,9 @@ pub(crate) fn cgroup_test() -> TestResult {
             return TestResult::Failed(anyhow!("container start failed"));
         }
 
+        exec_container(id, dir, &["grep", "^0::/$", "/proc/self/cgroup"], None, &[])
+            .expect("exec failed");
+
         // move init to a sub-cgroup, and check it was moved
         exec_container(
             id,
@@ -134,11 +137,7 @@ pub(crate) fn cgroup_test() -> TestResult {
         exec_container(
             id,
             dir,
-            &[
-                "sh",
-                "-euc",
-                "cat /proc/self/cgroup && grep '^0::/foobar$' /proc/self/cgroup",
-            ],
+            &["grep", "^0::/foobar$", "/proc/self/cgroup"],
             None,
             &[],
         )

--- a/tests/contest/contest/src/tests/exec/cgroup_test.rs
+++ b/tests/contest/contest/src/tests/exec/cgroup_test.rs
@@ -94,7 +94,7 @@ pub(crate) fn cgroup_test() -> TestResult {
             return TestResult::Failed(anyhow!("container start failed"));
         }
 
-        // move init to a subcgroup, and check it was moved
+        // move init to a sub-cgroup, and check it was moved
         exec_container(
             id,
             dir,
@@ -104,7 +104,13 @@ pub(crate) fn cgroup_test() -> TestResult {
         )
         .expect("exec failed");
 
-        // the init process is now in "/foo", but an exec process can still join "/" because we haven't enabled any domain controller yet
+        // the init process is now in "/foobar" sub-cgroup, so the exec process joins "/foobar" sub-cgroup.
+        // note:
+        //   this behavior differs from runc because youki adopts the "proactive inference" approach rather than runc's "retrying" approach.
+        //   see the discussion below for more details.
+        // ref (runc's behavior test): https://github.com/opencontainers/runc/blob/main/tests/integration/cgroups.bats#L99-L103
+        // ref (approach details): https://github.com/youki-dev/youki/pull/3347#issuecomment-4557652166
+        // ref (discussion): https://github.com/youki-dev/youki/pull/3347#issuecomment-5224550358
         exec_container(
             id,
             dir,
@@ -124,10 +130,7 @@ pub(crate) fn cgroup_test() -> TestResult {
         )
         .expect("exec failed");
 
-        // TODO: Implement the test cases discussed in
-        // https://github.com/youki-dev/youki/pull/3210#discussion_r2554961182.
-        // This depends on changes introduced by PR https://github.com/youki-dev/youki/pull/3347.
-        // an exec process can no longer join "/" after turning on a domain controller. Check that cgroup v2 fallback to init cgroup works
+        // the exec process still joins "/foobar" sub-cgroup after the domain controller is enabled.
         exec_container(
             id,
             dir,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Made a tenant container join the landlord init process’s sub-cgroup by setting the sub-cgroup path when the argument is empty.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
fixes #3342
fixes #3437 
refs #3347 
depends on #3563 

## Additional Context
<!-- Add any other context about the pull request here -->
https://github.com/youki-dev/youki/pull/3347#issuecomment-4557200770