### PR TITLE
refactor(contest): extract detached console-socket spawn into test_utils

### DIFF
--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -8,7 +8,7 @@ use std::os::unix::fs::symlink;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow, bail};
@@ -19,9 +19,8 @@ use test_framework::{ConditionalTest, TestGroup, TestResult};
 use crate::utils::{
     LifecycleStatus, WaitTarget, build_checkpoint_command, checkpoint_container, criu_has_feature,
     criu_installed, delete_container, exec_container, generate_uuid, get_container_pid,
-    get_runtime_path, handle_console_socket, is_runtime_youki, kill_container, net, prepare_bundle,
-    restore_container, set_config, try_checkpoint_container, wait_container_running,
-    wait_for_state,
+    get_runtime_path, is_runtime_youki, kill_container, net, prepare_bundle, restore_container,
+    run_container_with_console, set_config, try_checkpoint_container, wait_for_state,
 };
 
 /// Used as check_fn for all `ConditionalTests` in this module:
@@ -75,50 +74,12 @@ impl CrTestContext {
         self.restore_id = Some(rid);
     }
 
-    // TODO: Consider extracting this into test_utils.rs as run_container_with_console (see issue #3529)
     fn start(&self) -> Result<(), TestResult> {
-        let runtime_path = get_runtime_path();
-        let actual_bundle_path = self.bundle.path().join("bundle");
-        let console_socket = self.bundle.path().join("console.sock");
-        let listener = std::os::unix::net::UnixListener::bind(&console_socket)
-            .map_err(|e| TestResult::Failed(anyhow!("failed to bind console socket: {e}")))?;
-
-        let run_result = (|| -> Result<()> {
-            let mut child = std::process::Command::new(runtime_path)
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .arg("--root")
-                .arg(self.bundle.path().join("runtime"))
-                .arg("run")
-                .arg("-d")
-                .arg("--bundle")
-                .arg(&actual_bundle_path)
-                .arg("--console-socket")
-                .arg(&console_socket)
-                .arg(&self.id)
-                .current_dir(self.bundle.path())
-                .spawn()?;
-
-            let (stream, _) = listener.accept()?;
-            handle_console_socket(stream);
-
-            let status = child.wait()?;
-            if !status.success() {
-                bail!("run -d failed ({status})");
-            }
-
-            wait_container_running(&self.id, &self.bundle)?;
-            ping_container(self.bundle.path())
-        })();
-
-        if let Err(e) = run_result {
-            return Err(TestResult::Failed(anyhow!(
-                "container did not reach running state: {e}"
-            )));
-        }
-
-        Ok(())
+        run_container_with_console(&self.id, self.bundle.path())
+            // The container reads from /fifo, so verify it is actually alive and
+            // serving I/O before any checkpoint/restore is attempted.
+            .and_then(|()| ping_container(self.bundle.path()))
+            .map_err(|e| TestResult::Failed(anyhow!("container did not reach running state: {e}")))
     }
 }
 

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -10,7 +10,7 @@ pub use test_utils::{
     CreateOptions, LifecycleStatus, State, WaitTarget, build_checkpoint_command,
     checkpoint_container, create_container, criu_has_feature, criu_installed, delete_container,
     exec_container, get_container_pid, get_state, handle_console_socket, kill_container,
-    restore_container, start_container, test_inside_container, test_outside_container,
-    try_checkpoint_container, update_container, update_container_with_stdin,
-    wait_container_running, wait_for_state,
+    restore_container, run_container_with_console, start_container, test_inside_container,
+    test_outside_container, try_checkpoint_container, update_container,
+    update_container_with_stdin, wait_container_running, wait_for_state,
 };

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -534,6 +534,63 @@ pub fn wait_container_running<P: AsRef<Path>>(id: &str, dir: P) -> Result<()> {
     )
 }
 
+/// Runs a container in detached mode with a console socket and waits until it is running.
+///
+/// This mirrors runc's `run -d --console-socket` flow, which is required to exercise
+/// containers configured with `terminal: true` (such containers refuse to start without
+/// an active console socket to receive the PTY master fd).
+///
+/// The function binds a Unix socket at `<dir>/console.sock`, spawns the runtime with
+/// `run -d`, accepts the console socket connection and keeps the received PTY master open
+/// for the lifetime of the container (see [`handle_console_socket`]), then blocks until
+/// the container reaches the `Running` state.
+///
+/// `dir` is the test root directory following the layout produced by `prepare_bundle`:
+/// the runtime state lives under `<dir>/runtime` and the OCI bundle under `<dir>/bundle`.
+///
+/// On success the container is left running; the caller is responsible for cleanup
+/// (e.g. `kill_container`/`delete_container`).
+pub fn run_container_with_console<P: AsRef<Path>>(id: &str, dir: P) -> Result<()> {
+    let dir = dir.as_ref();
+    let bundle_path = dir.join("bundle");
+    let console_socket = dir.join("console.sock");
+
+    let listener = std::os::unix::net::UnixListener::bind(&console_socket)
+        .with_context(|| format!("failed to bind console socket at {console_socket:?}"))?;
+
+    let mut child = Command::new(get_runtime_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .arg("--root")
+        .arg(dir.join("runtime"))
+        .arg("run")
+        .arg("-d")
+        .arg("--bundle")
+        .arg(&bundle_path)
+        .arg("--console-socket")
+        .arg(&console_socket)
+        .arg(id)
+        .current_dir(dir)
+        .spawn()
+        .context("could not run container with console socket")?;
+
+    // Accept the runtime's connection and take ownership of the PTY master fd so it
+    // stays open while the container runs. Do this before waiting on the child, since
+    // `run -d` only detaches once the console socket handshake has completed.
+    let (stream, _) = listener
+        .accept()
+        .context("failed to accept console socket connection")?;
+    handle_console_socket(stream);
+
+    let status = child.wait().context("failed to wait for run -d")?;
+    if !status.success() {
+        bail!("run -d failed ({status})");
+    }
+
+    wait_container_running(id, dir)
+}
+
 pub fn handle_console_socket(stream: std::os::unix::net::UnixStream) {
     std::thread::spawn(move || {
         use std::io::{IoSliceMut, Read};


### PR DESCRIPTION
## Description

This is the follow-up refactor agreed during the review of #3493.

The checkpoint/restore suite needs to start a container with `terminal: true`,
which requires running it detached (`run -d --console-socket`) and then servicing
the console socket so the PTY master fd stays open for the container's lifetime.
That whole dance lived inside `CrTestContext::start`, so it was only reachable from
the C/R tests even though it is generally useful for any suite that wants to test
console sockets or detached runs.

This PR extracts it into a reusable `run_container_with_console(id, dir)` helper in
`tests/contest/contest/src/utils/test_utils.rs`:

- The helper binds `<dir>/console.sock`, spawns `run -d --console-socket`, accepts the
  connection and hands the stream to `handle_console_socket`, waits on the child, and
  blocks until the container is `Running`.
- `CrTestContext::start` now just calls the helper and keeps the C/R-specific FIFO
  `ping_container` check layered on top.
- The `// TODO: Consider extracting this into test_utils.rs ...` note that pointed at
  this issue is removed, and the now-unused imports (`Stdio`, `handle_console_socket`,
  `wait_container_running`) are dropped from the C/R module.

The behaviour of the existing tests is unchanged — this is a pure extraction so the
logic can be shared by future suites.

## Type of Change
- [x] Refactoring (no functional changes)

## Testing
- [x] Ran existing test suite

The C/R integration tests (`checkpoint_restore`) exercise this path through
`CrTestContext::start`; they run only on non-youki runtimes with CRIU installed, and
their behaviour is unchanged. `cargo +nightly fmt` is clean.

## Related Issues
Closes #3529

## Additional Context
Extraction was deferred out of #3493 to keep that PR focused on the core C/R features
and to review the shared test-utility change on its own, as discussed in
https://github.com/youki-dev/youki/pull/3493#discussion_r3179099731.
