### PR TITLE
fix(update): accept -1 for --pids-limit and honor 0 as a valid limit

### DIFF
--- a/crates/libcgroups/src/systemd/pids.rs
+++ b/crates/libcgroups/src/systemd/pids.rs
@@ -30,10 +30,12 @@ impl Controller for Pids {
 
 impl Pids {
     fn apply(pids: &LinuxPids, properties: &mut HashMap<&str, Variant>) {
-        let limit = if pids.limit() > 0 {
-            pids.limit() as u64
-        } else {
+        // Per the runtime-spec, a negative limit (e.g. -1) means no limit
+        // (u64::MAX / "infinity"), while 0 is a valid limit value.
+        let limit = if pids.limit() < 0 {
             u64::MAX
+        } else {
+            pids.limit() as u64
         };
 
         properties.insert(TASKS_MAX, Variant::U64(limit));
@@ -85,6 +87,8 @@ mod tests {
 
     #[test]
     fn test_pids_zero_limit() -> Result<()> {
+        // Per the runtime-spec, 0 is a valid limit value and must be honored
+        // as-is rather than being treated as unlimited.
         let resources = LinuxResourcesBuilder::default()
             .pids(LinuxPidsBuilder::default().limit(0).build()?)
             .build()?;
@@ -99,7 +103,7 @@ mod tests {
 
         let task_max = properties.get(TASKS_MAX).unwrap();
         let val = recast!(task_max, Variant)?;
-        assert_eq!(val, Variant::U64(u64::MAX));
+        assert_eq!(val, Variant::U64(0));
 
         Ok(())
     }

--- a/crates/libcgroups/src/v1/pids.rs
+++ b/crates/libcgroups/src/v1/pids.rs
@@ -41,10 +41,12 @@ impl StatsProvider for Pids {
 
 impl Pids {
     fn apply(root_path: &Path, pids: &LinuxPids) -> Result<(), WrappedIoError> {
-        let limit = if pids.limit() > 0 {
-            pids.limit().to_string()
-        } else {
+        // Per the runtime-spec, a negative limit (e.g. -1) means no limit ("max"),
+        // while 0 is a valid limit value and must be honored as-is.
+        let limit = if pids.limit() < 0 {
             "max".to_string()
+        } else {
+            pids.limit().to_string()
         };
 
         common::write_cgroup_file_str(root_path.join(CGROUP_PIDS_MAX), &limit)?;
@@ -78,7 +80,24 @@ mod tests {
     #[test]
     fn test_set_pids_max() {
         let tmp = tempfile::tempdir().unwrap();
-        set_fixture(tmp.path(), CGROUP_PIDS_MAX, "0").expect("set fixture for 0 pids");
+        set_fixture(tmp.path(), CGROUP_PIDS_MAX, "0").expect("set fixture for -1 pids");
+
+        // A negative limit (e.g. -1) means no limit ("max").
+        let pids = LinuxPidsBuilder::default().limit(-1).build().unwrap();
+
+        Pids::apply(tmp.path(), &pids).expect("apply pids");
+
+        let content =
+            std::fs::read_to_string(tmp.path().join(CGROUP_PIDS_MAX)).expect("Read pids contents");
+        assert_eq!("max".to_string(), content);
+    }
+
+    #[test]
+    fn test_set_pids_zero_is_a_valid_limit() {
+        // Per the runtime-spec, 0 is a valid limit value and must be written
+        // literally rather than being treated as "max".
+        let tmp = tempfile::tempdir().unwrap();
+        set_fixture(tmp.path(), CGROUP_PIDS_MAX, "max").expect("set fixture for 0 pids");
 
         let pids = LinuxPidsBuilder::default().limit(0).build().unwrap();
 
@@ -86,7 +105,7 @@ mod tests {
 
         let content =
             std::fs::read_to_string(tmp.path().join(CGROUP_PIDS_MAX)).expect("Read pids contents");
-        assert_eq!("max".to_string(), content);
+        assert_eq!("0".to_string(), content);
     }
 
     #[test]

--- a/crates/libcgroups/src/v2/pids.rs
+++ b/crates/libcgroups/src/v2/pids.rs
@@ -34,10 +34,12 @@ impl StatsProvider for Pids {
 
 impl Pids {
     fn apply(root_path: &Path, pids: &LinuxPids) -> Result<(), WrappedIoError> {
-        let limit = if pids.limit() > 0 {
-            pids.limit().to_string()
-        } else {
+        // Per the runtime-spec, a negative limit (e.g. -1) means no limit ("max"),
+        // while 0 is a valid limit value and must be honored as-is.
+        let limit = if pids.limit() < 0 {
             "max".to_string()
+        } else {
+            pids.limit().to_string()
         };
         common::write_cgroup_file(root_path.join("pids.max"), limit)
     }
@@ -68,7 +70,25 @@ mod tests {
     fn test_set_pids_max() {
         let pids_file_name = "pids.max";
         let tmp = tempfile::tempdir().unwrap();
-        set_fixture(tmp.path(), pids_file_name, "0").expect("set fixture for 0 pids");
+        set_fixture(tmp.path(), pids_file_name, "0").expect("set fixture for -1 pids");
+
+        // A negative limit (e.g. -1) means no limit ("max").
+        let pids = LinuxPidsBuilder::default().limit(-1).build().unwrap();
+
+        Pids::apply(tmp.path(), &pids).expect("apply pids");
+
+        let content =
+            std::fs::read_to_string(tmp.path().join(pids_file_name)).expect("Read pids contents");
+        assert_eq!("max".to_string(), content);
+    }
+
+    #[test]
+    fn test_set_pids_zero_is_a_valid_limit() {
+        // Per the runtime-spec, 0 is a valid limit value and must be written
+        // literally rather than being treated as "max".
+        let pids_file_name = "pids.max";
+        let tmp = tempfile::tempdir().unwrap();
+        set_fixture(tmp.path(), pids_file_name, "max").expect("set fixture for 0 pids");
 
         let pids = LinuxPidsBuilder::default().limit(0).build().unwrap();
 
@@ -76,6 +96,6 @@ mod tests {
 
         let content =
             std::fs::read_to_string(tmp.path().join(pids_file_name)).expect("Read pids contents");
-        assert_eq!("max".to_string(), content);
+        assert_eq!("0".to_string(), content);
     }
 }

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -51,11 +51,11 @@ pub struct Update {
     pub memory_reservation: Option<u64>,
 
     /// Set total memory + swap usage to num bytes. Use -1 to unset the limit (i.e. use unlimited swap).
-    #[arg(long)]
+    #[arg(long, allow_hyphen_values = true)]
     pub memory_swap: Option<i64>,
 
-    /// Set the maximum number of processes allowed in the container
-    #[arg(long)]
+    /// Set the maximum number of processes allowed in the container. Use -1 for no limit (i.e. `max`).
+    #[arg(long, allow_hyphen_values = true)]
     pub pids_limit: Option<i64>,
 
     /// Set the value for Intel RDT/CAT L3 cache schema.
@@ -69,4 +69,46 @@ pub struct Update {
     /// Container identifier
     #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Update;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        update: Update,
+    }
+
+    fn parse(args: &[&str]) -> Update {
+        Wrapper::parse_from(args).update
+    }
+
+    #[test]
+    fn pids_limit_accepts_negative_value() {
+        let update = parse(&["update", "--pids-limit", "-1", "container-id"]);
+        assert_eq!(update.pids_limit, Some(-1));
+        assert_eq!(update.container_id, "container-id");
+    }
+
+    #[test]
+    fn pids_limit_accepts_zero_and_positive() {
+        assert_eq!(
+            parse(&["update", "--pids-limit", "0", "id"]).pids_limit,
+            Some(0)
+        );
+        assert_eq!(
+            parse(&["update", "--pids-limit", "12345", "id"]).pids_limit,
+            Some(12345)
+        );
+    }
+
+    #[test]
+    fn memory_swap_accepts_negative_value() {
+        let update = parse(&["update", "--memory-swap", "-1", "container-id"]);
+        assert_eq!(update.memory_swap, Some(-1));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3594.

`youki update --pids-limit` diverged from the OCI runtime-spec (and from runc) in two ways:

1. **`--pids-limit -1` was rejected at CLI parse time** with `error: unexpected argument '-1' found`, because the argument did not permit hyphen-prefixed values.
2. **`--pids-limit 0` was written as `max`.** All three pids controllers (cgroup v1, v2, and systemd) treated *any* value `<= 0` as "unlimited".

The [runtime-spec](https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#pids) states:

> `limit` (int64, OPTIONAL) - specifies the maximum number of tasks in the cgroup, with `-1` indicating no limit (`max`).
>
> Note: Even though it may superficially seem redundant, `0` is a valid limit value for the `pids` cgroup controller from the kernel's perspective and SHOULD be treated as such by runtimes.

## Changes

- **liboci-cli**: add `allow_hyphen_values = true` to `--pids-limit` so `-1` is accepted as a value. The same fix is applied to `--memory-swap`, whose help text already documents `-1` to unset the swap limit but which had the identical parse bug.
- **libcgroups (v1 / v2 / systemd)**: treat only *negative* limits as unlimited (`max` / `u64::MAX`); write `0` and positive values literally, so `0` is honored as a valid limit per the spec.

## Behavior

| `--pids-limit` | before | after |
| --- | --- | --- |
| `12345` | `12345` | `12345` |
| `-1` | **parse error** | `max` |
| `0` | `max` | `0` |

Note on runc parity: runc writes `1` for `--pids-limit 0` (a runc-specific quirk), whereas this change writes `0` literally, which is what the runtime-spec requires ("0 is a valid limit value ... and SHOULD be treated as such").

## Tests

- `liboci-cli`: parse tests asserting `--pids-limit -1/0/12345` and `--memory-swap -1` are accepted.
- `libcgroups` v1/v2/systemd: negative limit → `max`/`u64::MAX`, and a new test asserting `0` is written literally.
