### PR TITLE
feat: bridge container PTY to host stdio for foreground run and exec

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -69,9 +69,9 @@ pub(super) struct ContainerBuilderImpl {
 }
 
 impl ContainerBuilderImpl {
-    pub(super) fn create(&mut self) -> Result<Pid, LibcontainerError> {
+    pub(super) fn create(&mut self) -> Result<(Pid, Option<OwnedFd>), LibcontainerError> {
         match self.run_container() {
-            Ok(pid) => Ok(pid),
+            Ok(ret) => Ok(ret),
             Err(outer) => {
                 // Only the init container should be cleaned up in the case of
                 // an error.
@@ -90,7 +90,7 @@ impl ContainerBuilderImpl {
         matches!(self.container_type, ContainerType::InitContainer)
     }
 
-    fn run_container(&mut self) -> Result<Pid, LibcontainerError> {
+    fn run_container(&mut self) -> Result<(Pid, Option<OwnedFd>), LibcontainerError> {
         let linux = self.spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
         let base_cgroups_path = utils::get_cgroup_path(linux.cgroups_path(), &self.container_id);
         let mut final_cgroups_path = base_cgroups_path;
@@ -192,11 +192,13 @@ impl ContainerBuilderImpl {
             pid_file: self.pid_file.to_owned(),
         };
 
-        let init_pid = process::container_main_process::container_main_process(&container_args)
-            .map_err(|err| {
-                tracing::error!("failed to run container process {}", err);
-                LibcontainerError::MainProcess(err)
-            })?;
+        let (init_pid, pty_master_fd) = process::container_main_process::container_main_process(
+            &container_args,
+        )
+        .map_err(|err| {
+            tracing::error!("failed to run container process {}", err);
+            LibcontainerError::MainProcess(err)
+        })?;
 
         let mut intel_rdt_dir = None;
         let mut intel_rdt_monitoring_dir = None;
@@ -220,7 +222,7 @@ impl ContainerBuilderImpl {
                 .save()?;
         }
 
-        Ok(init_pid)
+        Ok((init_pid, pty_master_fd))
     }
 
     fn cleanup_container(&self) -> Result<(), LibcontainerError> {

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -192,13 +192,13 @@ impl ContainerBuilderImpl {
             pid_file: self.pid_file.to_owned(),
         };
 
-        let (init_pid, pty_master_fd) = process::container_main_process::container_main_process(
-            &container_args,
-        )
-        .map_err(|err| {
-            tracing::error!("failed to run container process {}", err);
-            LibcontainerError::MainProcess(err)
-        })?;
+        let (init_pid, foreground_pty_fd) =
+            process::container_main_process::container_main_process(&container_args).map_err(
+                |err| {
+                    tracing::error!("failed to run container process {}", err);
+                    LibcontainerError::MainProcess(err)
+                },
+            )?;
 
         let mut intel_rdt_dir = None;
         let mut intel_rdt_monitoring_dir = None;
@@ -222,7 +222,7 @@ impl ContainerBuilderImpl {
                 .save()?;
         }
 
-        Ok((init_pid, pty_master_fd))
+        Ok((init_pid, foreground_pty_fd))
     }
 
     fn cleanup_container(&self) -> Result<(), LibcontainerError> {

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -20,7 +20,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let mut container = ContainerBuilder::new(
+    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -20,7 +20,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
+    /// let (mut container, _foreground_pty_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -16,7 +16,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let mut container = ContainerBuilder::new(
+    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -16,7 +16,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
+    /// let (mut container, _foreground_pty_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -16,7 +16,7 @@ impl Container {
     /// use nix::sys::signal::Signal;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let mut container = ContainerBuilder::new(
+    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -16,7 +16,7 @@ impl Container {
     /// use nix::sys::signal::Signal;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
+    /// let (mut container, _foreground_pty_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -13,7 +13,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let mut container = ContainerBuilder::new(
+    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -13,7 +13,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
+    /// let (mut container, _foreground_pty_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -13,7 +13,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let mut container = ContainerBuilder::new(
+    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -13,7 +13,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
+    /// let (mut container, _foreground_pty_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -14,7 +14,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let mut container = ContainerBuilder::new(
+    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -14,7 +14,7 @@ impl Container {
     /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
-    /// let (mut container, _pty_master_fd) = ContainerBuilder::new(
+    /// let (mut container, _foreground_pty_fd) = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -73,7 +74,7 @@ impl InitContainerBuilder {
     }
 
     /// Creates a new container
-    pub fn build(self) -> Result<Container, LibcontainerError> {
+    pub fn build(self) -> Result<(Container, Option<OwnedFd>), LibcontainerError> {
         let spec = self.load_spec()?;
         // validate terminal field against console socket presence before any side effects
         // (mirrors runc's checkTerminal called at the top of runner.run())
@@ -135,11 +136,11 @@ impl InitContainerBuilder {
             process_label: None,
         };
 
-        builder_impl.create()?;
+        let (_, pty_master_fd) = builder_impl.create()?;
 
         container.refresh_state()?;
 
-        Ok(container)
+        Ok((container, pty_master_fd))
     }
 
     fn create_container_dir(&self) -> Result<PathBuf, LibcontainerError> {

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -136,11 +136,11 @@ impl InitContainerBuilder {
             process_label: None,
         };
 
-        let (_, pty_master_fd) = builder_impl.create()?;
+        let (_, foreground_pty_fd) = builder_impl.create()?;
 
         container.refresh_state()?;
 
-        Ok((container, pty_master_fd))
+        Ok((container, foreground_pty_fd))
     }
 
     fn create_container_dir(&self) -> Result<PathBuf, LibcontainerError> {

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -47,6 +47,7 @@ pub struct TenantContainerBuilder {
     capabilities: Vec<String>,
     process: Option<PathBuf>,
     detached: bool,
+    tty: bool,
     as_sibling: bool,
     additional_gids: Vec<u32>,
     user: Option<u32>,
@@ -146,6 +147,7 @@ impl TenantContainerBuilder {
             capabilities: Vec::new(),
             process: None,
             detached: false,
+            tty: false,
             as_sibling: false,
             additional_gids: vec![],
             user: None,
@@ -202,6 +204,11 @@ impl TenantContainerBuilder {
         self
     }
 
+    pub fn with_tty(mut self, tty: bool) -> Self {
+        self.tty = tty;
+        self
+    }
+
     pub fn with_additional_gids(mut self, gids: Vec<u32>) -> Self {
         self.additional_gids = gids;
         self
@@ -238,7 +245,7 @@ impl TenantContainerBuilder {
     }
 
     /// Joins an existing container
-    pub fn build(self) -> Result<Pid, LibcontainerError> {
+    pub fn build(self) -> Result<(Pid, Option<OwnedFd>), LibcontainerError> {
         let container_dir = self.lookup_container_dir()?;
         let container = self.load_container_state(container_dir.clone())?;
         let mut spec = self.load_init_spec(&container)?;
@@ -289,7 +296,7 @@ impl TenantContainerBuilder {
             process_label: self.process_label,
         };
 
-        let pid = builder_impl.create()?;
+        let (pid, pty_master_fd) = builder_impl.create()?;
 
         let mut notify_socket = NotifySocket::new(notify_path);
         notify_socket.notify_container_start()?;
@@ -309,7 +316,7 @@ impl TenantContainerBuilder {
             match read(read_end.as_raw_fd(), &mut buf).map_err(LibcontainerError::OtherSyscall)? {
                 0 => {
                     if err_str_buf.is_empty() {
-                        return Ok(pid);
+                        return Ok((pid, pty_master_fd));
                     } else {
                         return Err(LibcontainerError::Other(
                             String::from_utf8_lossy(&err_str_buf).to_string(),
@@ -439,6 +446,8 @@ impl TenantContainerBuilder {
             }
 
             process_builder = process_builder.user(user_builder.build()?);
+
+            process_builder = process_builder.terminal(self.tty);
 
             process_builder.build()?
         };

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -296,7 +296,7 @@ impl TenantContainerBuilder {
             process_label: self.process_label,
         };
 
-        let (pid, pty_master_fd) = builder_impl.create()?;
+        let (pid, foreground_pty_fd) = builder_impl.create()?;
 
         let mut notify_socket = NotifySocket::new(notify_path);
         notify_socket.notify_container_start()?;
@@ -316,7 +316,7 @@ impl TenantContainerBuilder {
             match read(read_end.as_raw_fd(), &mut buf).map_err(LibcontainerError::OtherSyscall)? {
                 0 => {
                     if err_str_buf.is_empty() {
-                        return Ok((pid, pty_master_fd));
+                        return Ok((pid, foreground_pty_fd));
                     } else {
                         return Err(LibcontainerError::Other(
                             String::from_utf8_lossy(&err_str_buf).to_string(),

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -101,8 +101,13 @@ impl MainSender {
         Ok(())
     }
 
-    pub fn init_ready(&mut self) -> Result<(), ChannelError> {
-        self.sender.send(Message::InitReady)?;
+    pub fn init_ready(&mut self, pty_master_fd: Option<RawFd>) -> Result<(), ChannelError> {
+        if let Some(fd) = pty_master_fd {
+            self.sender
+                .send_fds(Message::InitReady, &[fd.as_raw_fd()])?;
+        } else {
+            self.sender.send(Message::InitReady)?;
+        }
 
         Ok(())
     }
@@ -231,18 +236,22 @@ impl MainReceiver {
         }
     }
 
-    /// Waits for associated init process to send ready message
-    /// and return the pid of init process which is forked by init process
-    pub fn wait_for_init_ready(&mut self) -> Result<(), ChannelError> {
-        let msg = self
-            .receiver
-            .recv()
-            .map_err(|err| ChannelError::ReceiveError {
+    /// Waits for the associated init process to send the ready message.
+    /// Returns the PTY master fd when the init process allocated a foreground
+    /// terminal (process.terminal=true without a console socket).
+    pub fn wait_for_init_ready(&mut self) -> Result<Option<OwnedFd>, ChannelError> {
+        let (msg, fds) = self.receiver.recv_with_fds::<[RawFd; 1]>().map_err(|err| {
+            ChannelError::ReceiveError {
                 msg: "waiting for init ready".to_string(),
                 source: err,
-            })?;
+            }
+        })?;
         match msg {
-            Message::InitReady => Ok(()),
+            // SAFETY: the fd (if any) was just received via SCM_RIGHTS with
+            // MSG_CMSG_CLOEXEC, so it is a fresh fd that we own.
+            Message::InitReady => Ok(fds
+                .and_then(|f| f.first().copied())
+                .map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })),
             // this case in unique and known enough to have a special error format
             Message::ExecFailed(err) => Err(ChannelError::ExecError(format!(
                 "error in executing process : {err}"
@@ -624,7 +633,7 @@ mod tests {
             }
             unistd::ForkResult::Child => {
                 sender
-                    .init_ready()
+                    .init_ready(None)
                     .with_context(|| "Failed to send init ready")?;
                 sender.close()?;
                 std::process::exit(0);

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -110,8 +110,13 @@ impl MainSender {
         Ok(())
     }
 
-    pub fn init_ready(&mut self) -> Result<(), ChannelError> {
-        self.sender.send(Message::InitReady)?;
+    pub fn init_ready(&mut self, pty_master_fd: Option<RawFd>) -> Result<(), ChannelError> {
+        if let Some(fd) = pty_master_fd {
+            self.sender
+                .send_fds(Message::InitReady, &[fd.as_raw_fd()])?;
+        } else {
+            self.sender.send(Message::InitReady)?;
+        }
 
         Ok(())
     }
@@ -262,18 +267,22 @@ impl MainReceiver {
         }
     }
 
-    /// Waits for associated init process to send ready message
-    /// and return the pid of init process which is forked by init process
-    pub fn wait_for_init_ready(&mut self) -> Result<(), ChannelError> {
-        let msg = self
-            .receiver
-            .recv()
-            .map_err(|err| ChannelError::ReceiveError {
+    /// Waits for the associated init process to send the ready message.
+    /// Returns the PTY master fd when the init process allocated a foreground
+    /// terminal (process.terminal=true without a console socket).
+    pub fn wait_for_init_ready(&mut self) -> Result<Option<OwnedFd>, ChannelError> {
+        let (msg, fds) = self.receiver.recv_with_fds::<[RawFd; 1]>().map_err(|err| {
+            ChannelError::ReceiveError {
                 msg: "waiting for init ready".to_string(),
                 source: err,
-            })?;
+            }
+        })?;
         match msg {
-            Message::InitReady => Ok(()),
+            // SAFETY: the fd (if any) was just received via SCM_RIGHTS with
+            // MSG_CMSG_CLOEXEC, so it is a fresh fd that we own.
+            Message::InitReady => Ok(fds
+                .and_then(|f| f.first().copied())
+                .map(|fd| unsafe { OwnedFd::from_raw_fd(fd) })),
             // this case in unique and known enough to have a special error format
             Message::ExecFailed(err) => Err(ChannelError::ExecError(format!(
                 "error in executing process : {err}"
@@ -719,7 +728,7 @@ mod tests {
             }
             unistd::ForkResult::Child => {
                 sender
-                    .init_ready()
+                    .init_ready(None)
                     .with_context(|| "Failed to send init ready")?;
                 sender.close()?;
                 std::process::exit(0);
@@ -849,7 +858,7 @@ mod tests {
     #[serial]
     fn test_recv_init_message_passes_through_protocol_message() -> Result<()> {
         let (mut sender, mut receiver) = main_channel()?;
-        sender.init_ready()?;
+        sender.init_ready(None)?;
         let (msg, fd) = receiver.recv_init_message()?;
         assert!(matches!(msg, Message::InitReady));
         assert!(fd.is_none());

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -110,8 +110,8 @@ impl MainSender {
         Ok(())
     }
 
-    pub fn init_ready(&mut self, pty_master_fd: Option<RawFd>) -> Result<(), ChannelError> {
-        if let Some(fd) = pty_master_fd {
+    pub fn init_ready(&mut self, foreground_pty_fd: Option<RawFd>) -> Result<(), ChannelError> {
+        if let Some(fd) = foreground_pty_fd {
             self.sender
                 .send_fds(Message::InitReady, &[fd.as_raw_fd()])?;
         } else {

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::path::PathBuf;
 
 use nix::sys::wait::{WaitStatus, waitpid};
@@ -49,7 +49,7 @@ pub enum ProcessError {
 
 type Result<T> = std::result::Result<T, ProcessError>;
 
-pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
+pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, Option<OwnedFd>)> {
     // We use a set of channels to communicate between parent and child process.
     // Each channel is uni-directional. Because we will pass these channel to
     // cloned process, we have to be deligent about closing any unused channel.
@@ -233,7 +233,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
         err
     })?;
 
-    init_main_receiver.wait_for_init_ready().map_err(|err| {
+    let pty_master_fd = init_main_receiver.wait_for_init_ready().map_err(|err| {
         tracing::error!("failed to wait for init ready: {}", err);
         err
     })?;
@@ -283,7 +283,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
         Err(err) => return Err(ProcessError::WaitIntermediateProcess(err)),
     };
 
-    Ok(init_pid)
+    Ok((init_pid, pty_master_fd))
 }
 
 fn setup_mapping(config: &UserNamespaceConfig, pid: Pid) -> Result<()> {

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -1,9 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::fs::File;
-use std::os::fd::AsRawFd;
-#[cfg(feature = "libseccomp")]
-use std::os::fd::OwnedFd;
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::path::PathBuf;
 
 use nix::sys::wait::{WaitStatus, waitpid};
@@ -49,7 +47,7 @@ pub enum ProcessError {
 
 type Result<T> = std::result::Result<T, ProcessError>;
 
-pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
+pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, Option<OwnedFd>)> {
     // We use a set of channels to communicate between parent and child process.
     // Each channel is uni-directional. Because we will pass these channel to
     // cloned process, we have to be deligent about closing any unused channel.
@@ -173,10 +171,10 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
 
     let mut sequence =
         InitRequestSequence::new(container_args.container_type, &container_args.spec);
-    loop {
+    let pty_master_fd = loop {
         let (msg, fd) = init_main_receiver.recv_init_message()?;
         match sequence.accept(&msg)? {
-            InitRequest::Ready => break,
+            InitRequest::Ready => break fd,
             InitRequest::Hooks => {
                 let hooks = container_args
                     .spec
@@ -223,7 +221,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
                 let _ = fd;
             }
         }
-    }
+    };
 
     // We don't need to send anything to the init process after this point, so
     // close the sender.
@@ -277,7 +275,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<Pid> {
         Err(err) => return Err(ProcessError::WaitIntermediateProcess(err)),
     };
 
-    Ok(init_pid)
+    Ok((init_pid, pty_master_fd))
 }
 
 /// One-shot init-side setup requests.

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -171,7 +171,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, Op
 
     let mut sequence =
         InitRequestSequence::new(container_args.container_type, &container_args.spec);
-    let pty_master_fd = loop {
+    let foreground_pty_fd = loop {
         let (msg, fd) = init_main_receiver.recv_init_message()?;
         match sequence.accept(&msg)? {
             InitRequest::Ready => break fd,
@@ -275,7 +275,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, Op
         Err(err) => return Err(ProcessError::WaitIntermediateProcess(err)),
     };
 
-    Ok((init_pid, pty_master_fd))
+    Ok((init_pid, foreground_pty_fd))
 }
 
 /// One-shot init-side setup requests.

--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -45,6 +45,7 @@ pub fn container_init_process(
     init_receiver: &mut channel::InitReceiver,
 ) -> Result<()> {
     let mut ctx = InitContext::try_from(args)?;
+    let terminal = ctx.process.terminal().unwrap_or_default();
 
     setsid().map_err(|err| {
         tracing::error!(?err, "failed to setsid to create a session");
@@ -57,8 +58,8 @@ pub fn container_init_process(
 
     memory_policy::setup_memory_policy(ctx.linux.memory_policy(), ctx.syscall.as_ref())?;
 
-    // If no console socket, set up stdio now
-    if args.console_socket.is_none() {
+    // No console (no socket, no terminal): pass the provided stdio through now
+    if args.console_socket.is_none() && !terminal {
         if let Some(stdin) = args.stdin {
             dup2(stdin, 0).map_err(InitProcessError::NixOther)?;
             close(stdin).map_err(InitProcessError::NixOther)?;
@@ -152,13 +153,24 @@ pub fn container_init_process(
     // mount=true for init (mount /dev/console), false for exec (already mounted)
     // See: https://github.com/opencontainers/runc/blob/v1.4.0/libcontainer/standard_init_linux.go
     // See: https://github.com/opencontainers/runc/blob/v1.4.0/libcontainer/setns_init_linux.go
-    if let Some(csocketfd) = args.console_socket {
+    let pty_master_fd = if args.console_socket.is_some() || terminal {
         let mount_console = matches!(args.container_type, ContainerType::InitContainer);
-        tty::setup_console(ctx.syscall.as_ref(), csocketfd, mount_console).map_err(|err| {
+        match tty::setup_console(
+            ctx.syscall.as_ref(),
+            args.console_socket,
+            mount_console,
+            ctx.process.console_size(),
+        )
+        .map_err(|err| {
             tracing::error!(?err, "failed to set up tty");
             InitProcessError::Tty(err)
-        })?;
-    }
+        })? {
+            tty::PtyMaster::Foreground(fd) => Some(fd),
+            tty::PtyMaster::SentToSocket => None,
+        }
+    } else {
+        None
+    };
 
     if let Some(personality) = ctx.linux.personality() {
         if let Some(flags) = personality.flags() {
@@ -432,13 +444,15 @@ pub fn container_init_process(
     // payload.  Note, because we are already inside the pid namespace, the pid
     // outside the pid namespace should be recorded by the intermediate process
     // already.
-    main_sender.init_ready().map_err(|err| {
-        tracing::error!(
-            ?err,
-            "failed to notify main process that init process is ready"
-        );
-        InitProcessError::Channel(err)
-    })?;
+    main_sender
+        .init_ready(pty_master_fd.as_ref().map(|fd| fd.as_raw_fd()))
+        .map_err(|err| {
+            tracing::error!(
+                ?err,
+                "failed to notify main process that init process is ready"
+            );
+            InitProcessError::Channel(err)
+        })?;
     main_sender.close().map_err(|err| {
         tracing::error!(?err, "failed to close down main sender in init process");
         InitProcessError::Channel(err)

--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -153,7 +153,7 @@ pub fn container_init_process(
     // mount=true for init (mount /dev/console), false for exec (already mounted)
     // See: https://github.com/opencontainers/runc/blob/v1.4.0/libcontainer/standard_init_linux.go
     // See: https://github.com/opencontainers/runc/blob/v1.4.0/libcontainer/setns_init_linux.go
-    let pty_master_fd = if args.console_socket.is_some() || terminal {
+    let foreground_pty_fd = if args.console_socket.is_some() || terminal {
         let mount_console = matches!(args.container_type, ContainerType::InitContainer);
         match tty::setup_console(
             ctx.syscall.as_ref(),
@@ -445,7 +445,7 @@ pub fn container_init_process(
     // outside the pid namespace should be recorded by the intermediate process
     // already.
     main_sender
-        .init_ready(pty_master_fd.as_ref().map(|fd| fd.as_raw_fd()))
+        .init_ready(foreground_pty_fd.as_ref().map(|fd| fd.as_raw_fd()))
         .map_err(|err| {
             tracing::error!(
                 ?err,

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -20,6 +20,7 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
 use std::path::{Path, PathBuf};
 
+use nix::pty;
 use nix::sys::socket::{self, UnixAddr};
 use nix::sys::stat::{SFlag, major, minor};
 use nix::sys::statfs::FsType;
@@ -97,7 +98,6 @@ pub enum TTYError {
 
 type Result<T> = std::result::Result<T, TTYError>;
 
-// TODO: Handling when there isn't console-socket.
 pub fn setup_console_socket(
     container_dir: &Path,
     console_socket_path: &Path,
@@ -263,51 +263,62 @@ fn verify_pty_slave(slave: &OwnedFd) -> Result<()> {
     })
 }
 
+#[derive(Debug)]
+pub enum PtyMaster {
+    SentToSocket,
+    Foreground(OwnedFd),
+}
+
 /// Setup console AFTER pivot_root.
 ///
 /// This function should be called AFTER pivot_root. This follows runc's approach:
 /// setupConsole is called after pivotRoot in prepareRootfs.
 ///
 /// The process:
-/// 1. Create PTY pair from /dev/pts/ptmx (we're already in the container)
+/// 1. Create PTY pair from /dev/pts/ptmx (we're already in the container),
+///    sized from `console_size` if given
 /// 2. Optionally mount PTY slave on /dev/console (bind mount) - only for init
-/// 3. Send PTY master to console socket
-/// 4. Set controlling terminal
-/// 5. Connect stdio to PTY slave
+/// 3. Set controlling terminal
+/// 4. Connect stdio to PTY slave
+/// 5. Send PTY master to the console socket, or return it to be bridged to the
+///    host stdio when no socket is given (foreground)
 ///
 /// # Arguments
-/// * `console_fd` - The console socket file descriptor
+/// * `console_fd` - The console socket file descriptor, if any
 /// * `mount` - Whether to mount PTY slave on /dev/console (true for init, false for exec)
+/// * `console_size` - The `process.consoleSize` from the spec, if any
 ///
 /// By creating PTY from container's devpts, the PTY belongs to a mount that
 /// exists within the container's namespace, which is required for CRIU checkpoint.
 ///
 /// See: https://github.com/opencontainers/runc/blob/v1.4.0/libcontainer/rootfs_linux.go
-pub fn setup_console(syscall: &dyn Syscall, console_fd: RawFd, mount: bool) -> Result<()> {
+pub fn setup_console(
+    syscall: &dyn Syscall,
+    console_fd: Option<RawFd>,
+    mount: bool,
+    console_size: Option<oci_spec::runtime::Box>,
+) -> Result<PtyMaster> {
+    let winsize = console_size.map(|size| pty::Winsize {
+        ws_row: size.height() as u16,
+        ws_col: size.width() as u16,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    });
     // Create PTY pair from /dev/pts/ptmx
     // After pivot_root, /dev/pts points to the container's devpts
-    let openpty_result = nix::pty::openpty(None, None)
+    let openpty_result = pty::openpty(&winsize, None)
         .map_err(|err| TTYError::CreatePseudoTerminal { source: err })?;
 
-    let master = &openpty_result.master;
-    let slave = &openpty_result.slave;
+    let (master, slave) = (openpty_result.master, openpty_result.slave);
 
     // Verify both master and slave are real PTY devices (CVE-2025-52565 mitigation)
-    verify_ptmx_handle(master)?;
-    verify_pty_slave(slave)?;
+    verify_ptmx_handle(&master)?;
+    verify_pty_slave(&slave)?;
 
     // Mount PTY slave on /dev/console (only for init container)
     if mount {
-        mount_console(syscall, slave)?;
+        mount_console(syscall, &slave)?;
     }
-
-    // Send PTY master to console socket
-    let pty_name: &[u8] = PTMX_PATH;
-    let iov = [IoSlice::new(pty_name)];
-    let fds = [master.as_raw_fd()];
-    let cmsg = socket::ControlMessage::ScmRights(&fds);
-    socket::sendmsg::<UnixAddr>(console_fd, &iov, &[cmsg], socket::MsgFlags::empty(), None)
-        .map_err(|err| TTYError::SendPtyMaster { source: err })?;
 
     // Set controlling terminal
     if unsafe { libc::ioctl(slave.as_raw_fd(), libc::TIOCSCTTY) } < 0 {
@@ -317,10 +328,23 @@ pub fn setup_console(syscall: &dyn Syscall, console_fd: RawFd, mount: bool) -> R
     // Connect stdio to PTY slave
     connect_stdio(&slave.as_raw_fd(), &slave.as_raw_fd(), &slave.as_raw_fd())?;
 
-    // Close console socket
-    close(console_fd).map_err(|err| TTYError::CloseConsoleSocket { source: err })?;
+    Ok(match console_fd {
+        Some(console_fd) => {
+            // Send PTY master to console socket
+            let pty_name: &[u8] = PTMX_PATH;
+            let iov = [IoSlice::new(pty_name)];
+            let fds = [master.as_raw_fd()];
+            let cmsg = socket::ControlMessage::ScmRights(&fds);
 
-    Ok(())
+            socket::sendmsg::<UnixAddr>(console_fd, &iov, &[cmsg], socket::MsgFlags::empty(), None)
+                .map_err(|err| TTYError::SendPtyMaster { source: err })?;
+
+            // Close console socket
+            close(console_fd).map_err(|err| TTYError::CloseConsoleSocket { source: err })?;
+            PtyMaster::SentToSocket
+        }
+        None => PtyMaster::Foreground(master),
+    })
 }
 
 /// Mount PTY slave on /dev/console.
@@ -464,7 +488,7 @@ mod tests {
         // mount=false because mounting /dev/console requires an actual container
         // environment with proper namespace setup (pivot_root completed).
         let syscall = create_syscall();
-        let status = setup_console(syscall.as_ref(), fd.into_raw_fd(), false);
+        let status = setup_console(syscall.as_ref(), Some(fd.into_raw_fd()), false, None);
 
         // restore the original std* before doing final assert
         dup2(old_stdin, StdIO::Stdin.into())?;
@@ -479,8 +503,8 @@ mod tests {
     #[test]
     fn test_verify_pty_slave_with_real_pty() -> Result<()> {
         // Allocate a real PTY pair
-        let openpty_result = nix::pty::openpty(None, None)
-            .map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
+        let openpty_result =
+            pty::openpty(None, None).map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
 
         // Verify slave handle should succeed
         let result = verify_pty_slave(&openpty_result.slave);
@@ -492,8 +516,8 @@ mod tests {
     #[test]
     fn test_verify_ptmx_handle_with_real_pty() -> Result<()> {
         // Allocate a real PTY pair
-        let openpty_result = nix::pty::openpty(None, None)
-            .map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
+        let openpty_result =
+            pty::openpty(None, None).map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
 
         // Verify ptmx handle should succeed
         let result = verify_ptmx_handle(&openpty_result.master);

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -20,6 +20,7 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
 use std::path::{Path, PathBuf};
 
+use nix::pty;
 use nix::sys::socket::{self, UnixAddr};
 use nix::sys::stat::{SFlag, major, minor};
 use nix::sys::statfs::FsType;
@@ -97,7 +98,6 @@ pub enum TTYError {
 
 type Result<T> = std::result::Result<T, TTYError>;
 
-// TODO: Handling when there isn't console-socket.
 pub fn setup_console_socket(
     container_dir: &Path,
     console_socket_path: &Path,
@@ -263,51 +263,62 @@ fn verify_pty_slave(slave: &OwnedFd) -> Result<()> {
     })
 }
 
+#[derive(Debug)]
+pub enum PtyMaster {
+    SentToSocket,
+    Foreground(OwnedFd),
+}
+
 /// Setup console AFTER pivot_root.
 ///
 /// This function should be called AFTER pivot_root. This follows runc's approach:
 /// setupConsole is called after pivotRoot in prepareRootfs.
 ///
 /// The process:
-/// 1. Create PTY pair from /dev/pts/ptmx (we're already in the container)
+/// 1. Create PTY pair from /dev/pts/ptmx (we're already in the container),
+///    sized from `console_size` if given
 /// 2. Optionally mount PTY slave on /dev/console (bind mount) - only for init
-/// 3. Send PTY master to console socket
-/// 4. Set controlling terminal
-/// 5. Connect stdio to PTY slave
+/// 3. Set controlling terminal
+/// 4. Connect stdio to PTY slave
+/// 5. Send PTY master to the console socket, or return it to be bridged to the
+///    host stdio when no socket is given (foreground)
 ///
 /// # Arguments
-/// * `console_fd` - The console socket file descriptor
+/// * `console_fd` - The console socket file descriptor, if any
 /// * `mount` - Whether to mount PTY slave on /dev/console (true for init, false for exec)
+/// * `console_size` - The `process.consoleSize` from the spec, if any
 ///
 /// By creating PTY from container's devpts, the PTY belongs to a mount that
 /// exists within the container's namespace, which is required for CRIU checkpoint.
 ///
 /// See: https://github.com/opencontainers/runc/blob/v1.4.0/libcontainer/rootfs_linux.go
-pub fn setup_console(syscall: &dyn Syscall, console_fd: RawFd, mount: bool) -> Result<()> {
+pub fn setup_console(
+    syscall: &dyn Syscall,
+    console_fd: Option<RawFd>,
+    mount: bool,
+    console_size: Option<oci_spec::runtime::Box>,
+) -> Result<PtyMaster> {
+    let winsize = console_size.map(|size| pty::Winsize {
+        ws_row: size.height() as u16,
+        ws_col: size.width() as u16,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    });
     // Create PTY pair from /dev/pts/ptmx
     // After pivot_root, /dev/pts points to the container's devpts
-    let openpty_result = nix::pty::openpty(None, None)
+    let openpty_result = pty::openpty(&winsize, None)
         .map_err(|err| TTYError::CreatePseudoTerminal { source: err })?;
 
-    let master = &openpty_result.master;
-    let slave = &openpty_result.slave;
+    let (master, slave) = (openpty_result.master, openpty_result.slave);
 
     // Verify both master and slave are real PTY devices (CVE-2025-52565 mitigation)
-    verify_ptmx_handle(master)?;
-    verify_pty_slave(slave)?;
+    verify_ptmx_handle(&master)?;
+    verify_pty_slave(&slave)?;
 
     // Mount PTY slave on /dev/console (only for init container)
     if mount {
-        mount_console(syscall, slave, Path::new(CONSOLE_PATH))?;
+        mount_console(syscall, &slave, Path::new(CONSOLE_PATH))?;
     }
-
-    // Send PTY master to console socket
-    let pty_name: &[u8] = PTMX_PATH;
-    let iov = [IoSlice::new(pty_name)];
-    let fds = [master.as_raw_fd()];
-    let cmsg = socket::ControlMessage::ScmRights(&fds);
-    socket::sendmsg::<UnixAddr>(console_fd, &iov, &[cmsg], socket::MsgFlags::empty(), None)
-        .map_err(|err| TTYError::SendPtyMaster { source: err })?;
 
     // Set controlling terminal
     if unsafe { libc::ioctl(slave.as_raw_fd(), libc::TIOCSCTTY) } < 0 {
@@ -317,10 +328,23 @@ pub fn setup_console(syscall: &dyn Syscall, console_fd: RawFd, mount: bool) -> R
     // Connect stdio to PTY slave
     connect_stdio(&slave.as_raw_fd(), &slave.as_raw_fd(), &slave.as_raw_fd())?;
 
-    // Close console socket
-    close(console_fd).map_err(|err| TTYError::CloseConsoleSocket { source: err })?;
+    Ok(match console_fd {
+        Some(console_fd) => {
+            // Send PTY master to console socket
+            let pty_name: &[u8] = PTMX_PATH;
+            let iov = [IoSlice::new(pty_name)];
+            let fds = [master.as_raw_fd()];
+            let cmsg = socket::ControlMessage::ScmRights(&fds);
 
-    Ok(())
+            socket::sendmsg::<UnixAddr>(console_fd, &iov, &[cmsg], socket::MsgFlags::empty(), None)
+                .map_err(|err| TTYError::SendPtyMaster { source: err })?;
+
+            // Close console socket
+            close(console_fd).map_err(|err| TTYError::CloseConsoleSocket { source: err })?;
+            PtyMaster::SentToSocket
+        }
+        None => PtyMaster::Foreground(master),
+    })
 }
 
 /// Mount PTY slave on /dev/console.
@@ -470,7 +494,7 @@ mod tests {
         // mount=false because mounting /dev/console requires an actual container
         // environment with proper namespace setup (pivot_root completed).
         let syscall = create_syscall();
-        let status = setup_console(syscall.as_ref(), fd.into_raw_fd(), false);
+        let status = setup_console(syscall.as_ref(), Some(fd.into_raw_fd()), false, None);
 
         // restore the original std* before doing final assert
         dup2(old_stdin, StdIO::Stdin.into())?;
@@ -485,8 +509,8 @@ mod tests {
     #[test]
     fn test_verify_pty_slave_with_real_pty() -> Result<()> {
         // Allocate a real PTY pair
-        let openpty_result = nix::pty::openpty(None, None)
-            .map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
+        let openpty_result =
+            pty::openpty(None, None).map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
 
         // Verify slave handle should succeed
         let result = verify_pty_slave(&openpty_result.slave);
@@ -498,8 +522,8 @@ mod tests {
     #[test]
     fn test_verify_ptmx_handle_with_real_pty() -> Result<()> {
         // Allocate a real PTY pair
-        let openpty_result = nix::pty::openpty(None, None)
-            .map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
+        let openpty_result =
+            pty::openpty(None, None).map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
 
         // Verify ptmx handle should succeed
         let result = verify_ptmx_handle(&openpty_result.master);

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -24,6 +24,7 @@ use nix::pty;
 use nix::sys::socket::{self, UnixAddr};
 use nix::sys::stat::{SFlag, major, minor};
 use nix::sys::statfs::FsType;
+use nix::sys::termios::{self, OutputFlags, SetArg};
 use nix::unistd::{close, dup2};
 
 use crate::syscall::Syscall;
@@ -80,6 +81,8 @@ pub enum TTYError {
     CreateConsoleSocketFd { source: nix::Error },
     #[error("could not create pseudo terminal")]
     CreatePseudoTerminal { source: nix::Error },
+    #[error("failed to clear ONLCR on pty")]
+    ClearOnlcr { source: nix::Error },
     #[error("failed to send pty master")]
     SendPtyMaster { source: nix::Error },
     #[error("could not close console socket")]
@@ -343,8 +346,27 @@ pub fn setup_console(
             close(console_fd).map_err(|err| TTYError::CloseConsoleSocket { source: err })?;
             PtyMaster::SentToSocket
         }
-        None => PtyMaster::Foreground(master),
+        None => {
+            clear_onlcr(&master)?;
+            PtyMaster::Foreground(master)
+        }
     })
+}
+
+/// Clear the ONLCR output flag on the PTY so the container's "\n" is not
+/// rewritten to "\r\n": a not-very-well-known default of Linux unix98 ptys is
+/// that they have +onlcr.
+///
+/// runc does the same for the foreground path only ((*tty).recvtty); for the
+/// console-socket path the receiver of the master owns the termios, so it is
+/// left untouched there.
+///
+/// See: https://github.com/opencontainers/runc/blob/v1.4.0/tty.go
+fn clear_onlcr(pty: &OwnedFd) -> Result<()> {
+    let mut attrs = termios::tcgetattr(pty).map_err(|err| TTYError::ClearOnlcr { source: err })?;
+    attrs.output_flags.remove(OutputFlags::ONLCR);
+    termios::tcsetattr(pty, SetArg::TCSANOW, &attrs)
+        .map_err(|err| TTYError::ClearOnlcr { source: err })
 }
 
 /// Mount PTY slave on /dev/console.
@@ -502,6 +524,23 @@ mod tests {
         dup2(old_stderr, StdIO::Stderr.into())?;
 
         assert!(status.is_ok(), "setup_console failed: {:?}", status);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_clear_onlcr() -> Result<()> {
+        let openpty_result =
+            pty::openpty(None, None).map_err(|e| TTYError::CreatePseudoTerminal { source: e })?;
+
+        // Linux unix98 ptys default to +onlcr.
+        let attrs = termios::tcgetattr(&openpty_result.master)?;
+        assert!(attrs.output_flags.contains(OutputFlags::ONLCR));
+
+        clear_onlcr(&openpty_result.master)?;
+
+        let attrs = termios::tcgetattr(&openpty_result.master)?;
+        assert!(!attrs.output_flags.contains(OutputFlags::ONLCR));
 
         Ok(())
     }

--- a/crates/libcontainer/tests/as_sibling.rs
+++ b/crates/libcontainer/tests/as_sibling.rs
@@ -66,7 +66,7 @@ fn run_init_process_as_child() -> Result<()> {
     prepare_container_root(&root)?;
 
     let id = format!("test-container-{:x}", hash(root.as_ref()));
-    let container = ContainerBuilder::new(id, SyscallType::Linux)
+    let (container, _pty_master_fd) = ContainerBuilder::new(id, SyscallType::Linux)
         .with_executor(SomeExecutor)
         .with_root_path(root.as_ref())?
         .as_init(root.as_ref())
@@ -93,7 +93,7 @@ fn run_init_process_as_sibling() -> Result<()> {
     prepare_container_root(&root)?;
 
     let id = format!("test-container-{:x}", hash(root.as_ref()));
-    let container = ContainerBuilder::new(id, SyscallType::Linux)
+    let (container, _pty_master_fd) = ContainerBuilder::new(id, SyscallType::Linux)
         .with_executor(SomeExecutor)
         .with_root_path(root.as_ref())?
         .as_init(root.as_ref())

--- a/crates/libcontainer/tests/as_sibling.rs
+++ b/crates/libcontainer/tests/as_sibling.rs
@@ -66,7 +66,7 @@ fn run_init_process_as_child() -> Result<()> {
     prepare_container_root(&root)?;
 
     let id = format!("test-container-{:x}", hash(root.as_ref()));
-    let (container, _pty_master_fd) = ContainerBuilder::new(id, SyscallType::Linux)
+    let (container, _foreground_pty_fd) = ContainerBuilder::new(id, SyscallType::Linux)
         .with_executor(SomeExecutor)
         .with_root_path(root.as_ref())?
         .as_init(root.as_ref())
@@ -93,7 +93,7 @@ fn run_init_process_as_sibling() -> Result<()> {
     prepare_container_root(&root)?;
 
     let id = format!("test-container-{:x}", hash(root.as_ref()));
-    let (container, _pty_master_fd) = ContainerBuilder::new(id, SyscallType::Linux)
+    let (container, _foreground_pty_fd) = ContainerBuilder::new(id, SyscallType::Linux)
         .with_executor(SomeExecutor)
         .with_root_path(root.as_ref())?
         .as_init(root.as_ref())

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { workspace = true, features = ["clock", "serde"] }
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.7.0" } # MARK: Version
 libcontainer = { path = "../libcontainer", default-features = false, version = "0.7.0" } # MARK: Version
 liboci-cli = { workspace = true }
-nix = { workspace = true }
+nix = { workspace = true, features = ["event", "poll"] }
 pentacle = { workspace = true }
 procfs = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -4,36 +4,38 @@ use anyhow::Result;
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::syscall::syscall::SyscallType;
 use liboci_cli::Exec;
-use nix::sys::wait::{WaitStatus, waitpid};
 
+use crate::commands::foreground;
 use crate::workload::executor::default_executor;
 
 pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
     let user = args.user.map(|(u, _)| u);
     let group = args.user.and_then(|(_, g)| g);
 
-    let pid = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
-        .with_executor(default_executor())
-        .with_root_path(root_path)?
-        .with_console_socket(args.console_socket.as_ref())
-        .with_pid_file(args.pid_file.as_ref())?
-        .with_preserved_fds(args.preserve_fds)
-        .validate_id()?
-        .as_tenant()
-        .with_detach(args.detach)
-        .with_cwd(args.cwd.as_ref())
-        .with_env(args.env.clone().into_iter().collect())
-        .with_process(args.process.as_ref())
-        .with_no_new_privs(args.no_new_privs)
-        .with_container_args(args.command.clone())
-        .with_additional_gids(args.additional_gids)
-        .with_user(user)
-        .with_group(group)
-        .with_capabilities(args.cap)
-        .with_ignore_paused(args.ignore_paused)
-        .with_sub_cgroup(args.cgroup)
-        .with_apparmor(args.apparmor)
-        .build()?;
+    let (pid, pty_master_fd) =
+        ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
+            .with_executor(default_executor())
+            .with_root_path(root_path)?
+            .with_console_socket(args.console_socket.as_ref())
+            .with_pid_file(args.pid_file.as_ref())?
+            .with_preserved_fds(args.preserve_fds)
+            .validate_id()?
+            .as_tenant()
+            .with_detach(args.detach)
+            .with_cwd(args.cwd.as_ref())
+            .with_env(args.env.clone().into_iter().collect())
+            .with_process(args.process.as_ref())
+            .with_no_new_privs(args.no_new_privs)
+            .with_container_args(args.command.clone())
+            .with_additional_gids(args.additional_gids)
+            .with_user(user)
+            .with_group(group)
+            .with_capabilities(args.cap)
+            .with_ignore_paused(args.ignore_paused)
+            .with_sub_cgroup(args.cgroup)
+            .with_apparmor(args.apparmor)
+            .with_tty(args.tty)
+            .build()?;
 
     // See https://github.com/youki-dev/youki/pull/1252 for a detailed explanation
     // basically, if there is any error in starting exec, the build above will return error
@@ -43,9 +45,5 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
         return Ok(0);
     }
 
-    match waitpid(pid, None)? {
-        WaitStatus::Exited(_, status) => Ok(status),
-        WaitStatus::Signaled(_, sig, _) => Ok(sig as i32),
-        _ => Ok(0),
-    }
+    foreground::handle_foreground(pid, pty_master_fd)
 }

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -12,7 +12,7 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
     let user = args.user.map(|(u, _)| u);
     let group = args.user.and_then(|(_, g)| g);
 
-    let (pid, pty_master_fd) =
+    let (pid, foreground_pty_fd) =
         ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
             .with_executor(default_executor())
             .with_root_path(root_path)?
@@ -45,5 +45,5 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
         return Ok(0);
     }
 
-    foreground::handle_foreground(pid, pty_master_fd)
+    foreground::handle_foreground(pid, foreground_pty_fd)
 }

--- a/crates/youki/src/commands/foreground.rs
+++ b/crates/youki/src/commands/foreground.rs
@@ -1,0 +1,363 @@
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::thread::JoinHandle;
+
+use anyhow::{Context, Result};
+use nix::sys::signal::{self, kill};
+use nix::sys::signalfd::SigSet;
+use nix::sys::termios::{self, Termios};
+use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
+use nix::unistd::Pid;
+use nix::{libc, unistd};
+
+struct RawTerminalGuard {
+    original: Termios,
+}
+
+impl RawTerminalGuard {
+    fn new() -> Result<Option<Self>> {
+        let stdin = io::stdin();
+        if !unistd::isatty(stdin.as_raw_fd())? {
+            return Ok(None);
+        }
+
+        let stdin_fd = stdin.as_fd();
+        let original =
+            termios::tcgetattr(stdin_fd).with_context(|| "failed to get terminal attributes")?;
+        let mut raw = original.clone();
+        termios::cfmakeraw(&mut raw);
+        termios::tcsetattr(&stdin, termios::SetArg::TCSANOW, &raw)
+            .with_context(|| "failed to set raw terminal attributes")?;
+
+        Ok(Some(Self { original }))
+    }
+}
+
+impl Drop for RawTerminalGuard {
+    fn drop(&mut self) {
+        // There is nothing we can do if this fails, so ignore the error.
+        let _ = termios::tcsetattr(io::stdin(), termios::SetArg::TCSANOW, &self.original);
+    }
+}
+
+// Bridge host stdio <-> the container's PTY master; returns the PTY->stdout relay's join handle.
+fn io_bridge(master: OwnedFd) -> Result<JoinHandle<()>> {
+    let master_clone = master
+        .try_clone()
+        .with_context(|| "failed to duplicate pty master fd")?;
+
+    // host stdin -> PTY master (detached; blocks on stdin until exit).
+    std::thread::spawn(move || {
+        let mut master_file = File::from(master);
+        // Errors are ignored: when the container exits, the PTY master
+        // returns EIO, which is the normal way to exit this loop.
+        let _ = io::copy(&mut io::stdin(), &mut master_file);
+    });
+
+    // PTY master -> host stdout (joined on drop to flush the last bytes).
+    let output = std::thread::spawn(move || {
+        let mut master_file = File::from(master_clone);
+        if let Ok(stdout_fd) = io::stdout().as_fd().try_clone_to_owned() {
+            let mut out = File::from(stdout_fd);
+            let _ = io::copy(&mut master_file, &mut out);
+        }
+    });
+
+    Ok(output)
+}
+
+/// Foreground console state. On drop it drains the PTY->stdout relay (so the last output is not
+/// lost) and restores the terminal, so hold it for the whole lifetime — never bind it to `_`.
+struct ConsoleBridge {
+    raw: Option<RawTerminalGuard>,
+    output: Option<JoinHandle<()>>,
+    // A dup of the PTY master kept so SIGWINCH can resize the container terminal.
+    resize: OwnedFd,
+}
+
+impl ConsoleBridge {
+    /// Propagate the host terminal's current window size to the container PTY master.
+    fn resize_to_host(&self) {
+        let stdin = io::stdin();
+        if !unistd::isatty(stdin.as_raw_fd()).unwrap_or(false) {
+            return;
+        }
+
+        let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+        if unsafe { libc::ioctl(stdin.as_raw_fd(), libc::TIOCGWINSZ, &mut ws) } < 0 {
+            return;
+        }
+        unsafe { libc::ioctl(self.resize.as_raw_fd(), libc::TIOCSWINSZ, &ws) };
+    }
+}
+
+impl Drop for ConsoleBridge {
+    fn drop(&mut self) {
+        // Restore the terminal first so a stuck relay cannot leave it in raw mode.
+        drop(self.raw.take());
+        // The relay ends when every PTY slave closes (container exit) and the master read hits EIO.
+        if let Some(output) = self.output.take() {
+            let _ = output.join();
+        }
+    }
+}
+
+/// With a PTY master, raw-mode the host terminal and bridge host stdio <-> the PTY.
+fn attach_console(master: Option<OwnedFd>) -> Result<Option<ConsoleBridge>> {
+    match master {
+        Some(master) => {
+            let raw = RawTerminalGuard::new()?;
+            let resize = master
+                .try_clone()
+                .with_context(|| "failed to duplicate pty master fd")?;
+            let output = io_bridge(master)?;
+            Ok(Some(ConsoleBridge {
+                raw,
+                output: Some(output),
+                resize,
+            }))
+        }
+        None => Ok(None),
+    }
+}
+
+// handle_foreground will match the `runc` behavior running the foreground mode.
+// The youki main process will wait and reap the container init process. The
+// youki main process also forwards most of the signals to the container init
+// process.
+#[tracing::instrument(level = "trace")]
+pub(crate) fn handle_foreground(init_pid: Pid, pty_master_fd: Option<OwnedFd>) -> Result<i32> {
+    tracing::trace!("waiting for container init process to exit");
+
+    // We mask all signals here and forward most of the signals to the container
+    // init process.
+    let signal_set = SigSet::all();
+    signal_set
+        .thread_block()
+        .with_context(|| "failed to call pthread_sigmask")?;
+
+    // With a PTY master, raw-mode the host terminal (restored on drop) and bridge stdio.
+    let console = attach_console(pty_master_fd)?;
+    if let Some(console) = &console {
+        console.resize_to_host();
+    }
+
+    if let Some(status) = reap_children(init_pid)? {
+        return Ok(status);
+    }
+
+    loop {
+        match signal_set
+            .wait()
+            .with_context(|| "failed to call sigwait")?
+        {
+            signal::SIGCHLD => {
+                // Reap all child until either container init process exits or
+                // no more child to be reaped. Once the container init process
+                // exits we can then return.
+                tracing::trace!("reaping child processes");
+                if let Some(status) = reap_children(init_pid)? {
+                    return Ok(status);
+                }
+            }
+            signal::SIGURG => {
+                // In `runc`, SIGURG is used by go runtime and should not be forwarded to
+                // the container process. Here, we just ignore the signal.
+            }
+            signal::SIGWINCH => {
+                if let Some(console) = &console {
+                    console.resize_to_host();
+                }
+            }
+            signal => {
+                tracing::trace!(?signal, "forwarding signal");
+                // There is nothing we can do if we fail to forward the signal.
+                let _ = kill(init_pid, Some(signal)).map_err(|err| {
+                    tracing::warn!(
+                        ?err,
+                        ?signal,
+                        "failed to forward signal to container init process",
+                    );
+                });
+            }
+        }
+    }
+}
+
+fn reap_children(init_pid: Pid) -> Result<Option<i32>> {
+    loop {
+        match waitpid(None, Some(WaitPidFlag::WNOHANG))? {
+            WaitStatus::Exited(pid, status) => {
+                if pid.eq(&init_pid) {
+                    return Ok(Some(status));
+                }
+
+                // Else, some random child process exited, ignoring...
+            }
+            WaitStatus::Signaled(pid, signal, _) => {
+                if pid.eq(&init_pid) {
+                    return Ok(Some(signal as i32));
+                }
+
+                // Else, some random child process exited, ignoring...
+            }
+            WaitStatus::StillAlive => {
+                // No more child to reap.
+                return Ok(None);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use nix::sys::signal::Signal::{SIGINT, SIGKILL};
+    use nix::sys::wait;
+    use nix::unistd;
+
+    use super::*;
+
+    #[test]
+    fn test_foreground_forward_sig() -> Result<()> {
+        // To set up the test correctly, we need to run the test in dedicated
+        // process, so the rust unit test runtime and other unit tests will not
+        // mess with the signal handling. We use `sigkill` as a simple way to
+        // make sure the signal is properly forwarded. In this test, P0 is the
+        // rust process that runs this unit test (in a thread). P1 mocks youki
+        // main and P2 mocks the container init process
+        match unsafe { unistd::fork()? } {
+            unistd::ForkResult::Parent { child } => {
+                // Inside P0
+                //
+                // We need to make sure that the child process has entered into
+                // the signal forwarding loops. There is no way to 100% sync
+                // that the child has executed the for loop waiting to forward
+                // the signal. There are sync mechanisms with condvar or
+                // channels to make it as close to calling the handle_foreground
+                // function as possible, but still have a tiny (highly unlikely
+                // but probable) window that a race can still happen. So instead
+                // we just wait for 1 second for everything to settle. In
+                // general, I don't like sleep in tests to avoid race condition,
+                // but I'd rather not over-engineer this now. We can revisit
+                // this later if the test becomes flaky.
+                std::thread::sleep(Duration::from_secs(1));
+                // Send the `sigint` signal to P1 who will forward the signal
+                // to P2. P2 will then exit and send a sigchld to P1. P1 will
+                // then reap P2 and exits. In P0, we can then reap P1.
+                kill(child, SIGINT)?;
+                wait::waitpid(child, None)?;
+            }
+            unistd::ForkResult::Child => {
+                // Inside P1. Fork P2 as mock container init process and run
+                // signal handler process inside.
+                match unsafe { unistd::fork()? } {
+                    unistd::ForkResult::Parent { child } => {
+                        // Inside P1.
+                        let _ = handle_foreground(child, None).map_err(|err| {
+                            // Since we are in a child process, we want to use trace to log the error.
+                            let _ = tracing_subscriber::fmt()
+                                .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+                                .try_init();
+                            tracing::error!(?err, "failed to handle foreground");
+                            err
+                        });
+                        std::process::exit(0);
+                    }
+                    unistd::ForkResult::Child => {
+                        let mut signal_set = SigSet::empty();
+                        signal_set.add(SIGINT);
+                        signal_set.thread_block()?;
+                        signal_set.wait()?;
+                        std::process::exit(0);
+                    }
+                };
+            }
+        };
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_foreground_already_exited_child() -> Result<()> {
+        // The container process can exit before handle_foreground blocks
+        // signals; the SIGCHLD is then delivered and discarded, so sigwait
+        // alone would block forever. handle_foreground must reap the zombie
+        // that is already there. P0 = test, P1 = mock youki, P2 = mock init.
+        match unsafe { unistd::fork()? } {
+            unistd::ForkResult::Parent { child } => {
+                // Inside P0. P1 must finish on its own; kill it if it hangs.
+                let deadline = std::time::Instant::now() + Duration::from_secs(5);
+                loop {
+                    match wait::waitpid(child, Some(WaitPidFlag::WNOHANG))? {
+                        WaitStatus::StillAlive => {
+                            if std::time::Instant::now() > deadline {
+                                let _ = kill(child, SIGKILL);
+                                let _ = wait::waitpid(child, None);
+                                panic!("handle_foreground hung on a pre-exited child");
+                            }
+                            std::thread::sleep(Duration::from_millis(50));
+                        }
+                        status => {
+                            assert_eq!(status, WaitStatus::Exited(child, 0));
+                            break;
+                        }
+                    }
+                }
+            }
+            unistd::ForkResult::Child => {
+                // Inside P1. P2 exits immediately; sleep long enough that its
+                // SIGCHLD is delivered (and discarded) before handle_foreground.
+                match unsafe { unistd::fork() } {
+                    Ok(unistd::ForkResult::Parent { child }) => {
+                        std::thread::sleep(Duration::from_millis(500));
+                        let code = match handle_foreground(child, None) {
+                            Ok(_) => 0,
+                            Err(_) => 1,
+                        };
+                        std::process::exit(code);
+                    }
+                    Ok(unistd::ForkResult::Child) => std::process::exit(0),
+                    Err(_) => std::process::exit(1),
+                }
+            }
+        };
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_foreground_exit() -> Result<()> {
+        // The setup is similar to `handle_foreground`, but instead of
+        // forwarding signal, the container init process will exit. Again, we
+        // use `sleep` to simulate the conditions to avoid fine grained
+        // synchronization for now.
+        match unsafe { unistd::fork()? } {
+            unistd::ForkResult::Parent { child } => {
+                // Inside P0
+                std::thread::sleep(Duration::from_secs(1));
+                wait::waitpid(child, None)?;
+            }
+            unistd::ForkResult::Child => {
+                // Inside P1. Fork P2 as mock container init process and run
+                // signal handler process inside.
+                match unsafe { unistd::fork()? } {
+                    unistd::ForkResult::Parent { child } => {
+                        // Inside P1.
+                        handle_foreground(child, None)?;
+                        wait::waitpid(child, None)?;
+                    }
+                    unistd::ForkResult::Child => {
+                        // Inside P2. The process exits after 1 second.
+                        std::thread::sleep(Duration::from_secs(1));
+                    }
+                };
+            }
+        };
+
+        Ok(())
+    }
+}

--- a/crates/youki/src/commands/foreground.rs
+++ b/crates/youki/src/commands/foreground.rs
@@ -1,9 +1,12 @@
 use std::fs::File;
-use std::io;
+use std::io::{self, Read, Write};
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use anyhow::{Context, Result};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+use nix::sys::eventfd::{EfdFlags, EventFd};
 use nix::sys::signal::{self, kill};
 use nix::sys::signalfd::SigSet;
 use nix::sys::termios::{self, Termios};
@@ -41,8 +44,24 @@ impl Drop for RawTerminalGuard {
     }
 }
 
-// Bridge host stdio <-> the container's PTY master; returns the PTY->stdout relay's join handle.
-fn io_bridge(master: OwnedFd) -> Result<JoinHandle<()>> {
+// Owns the PTY output thread and the eventfd used to wake it during foreground shutdown.
+struct OutputRelay {
+    stop: Arc<EventFd>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for OutputRelay {
+    fn drop(&mut self) {
+        let _ = self.stop.arm();
+
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+// Bridge host stdio with the container PTY and return a stoppable output relay.
+fn io_bridge(master: OwnedFd) -> Result<OutputRelay> {
     let master_clone = master
         .try_clone()
         .with_context(|| "failed to duplicate pty master fd")?;
@@ -55,56 +74,134 @@ fn io_bridge(master: OwnedFd) -> Result<JoinHandle<()>> {
         let _ = io::copy(&mut io::stdin(), &mut master_file);
     });
 
-    // PTY master -> host stdout (joined on drop to flush the last bytes).
-    let output = std::thread::spawn(move || {
+    // PTY master -> host stdout. The relay is explicitly stopped and joined on drop.
+    let stop = Arc::new(
+        EventFd::from_flags(EfdFlags::EFD_CLOEXEC)
+            .with_context(|| "failed to create output relay eventfd")?,
+    );
+    let thread_stop = Arc::clone(&stop);
+    let thread = std::thread::spawn(move || {
         let mut master_file = File::from(master_clone);
-        if let Ok(stdout_fd) = io::stdout().as_fd().try_clone_to_owned() {
-            let mut out = File::from(stdout_fd);
-            let _ = io::copy(&mut master_file, &mut out);
-        }
+
+        let Ok(stdout_fd) = io::stdout().as_fd().try_clone_to_owned() else {
+            return;
+        };
+        let mut out = File::from(stdout_fd);
+
+        let _ = relay_output(&mut master_file, &mut out, &thread_stop).map_err(|err| {
+            tracing::warn!(?err, "failed to relay output from pty master to stdout");
+        });
     });
 
-    Ok(output)
+    Ok(OutputRelay {
+        stop,
+        thread: Some(thread),
+    })
+}
+
+// Relay PTY output until the master closes or the owning foreground process requests shutdown.
+fn relay_output(master: &mut File, out: &mut File, stop: &EventFd) -> io::Result<()> {
+    let mut buffer = [0_u8; 8192];
+
+    loop {
+        let (master_events, stop_events) = {
+            let mut fds = [
+                PollFd::new(master.as_fd(), PollFlags::POLLIN),
+                PollFd::new(stop.as_fd(), PollFlags::POLLIN),
+            ];
+
+            poll(&mut fds, PollTimeout::NONE)?;
+
+            (
+                fds[0].revents().unwrap_or(PollFlags::empty()),
+                fds[1].revents().unwrap_or(PollFlags::empty()),
+            )
+        };
+
+        if master_events.intersects(PollFlags::POLLIN | PollFlags::POLLHUP | PollFlags::POLLERR) {
+            match master.read(&mut buffer) {
+                Ok(0) => return Ok(()),
+                Ok(read) => out.write_all(&buffer[..read])?,
+                Err(err) if err.raw_os_error() == Some(libc::EIO) => return Ok(()),
+                Err(err) => return Err(err),
+            }
+        }
+
+        if stop_events.contains(PollFlags::POLLIN) {
+            drain_pending_output(master, out, &mut buffer)?;
+            return Ok(());
+        }
+    }
+}
+
+// Drain output while the PTY master is immediately readable. The zero timeout avoids waiting for
+// a descendant that keeps the PTY slave open after the queued output has been consumed.
+fn drain_pending_output(master: &mut File, out: &mut File, buffer: &mut [u8]) -> io::Result<()> {
+    loop {
+        let master_events = {
+            let mut fds = [PollFd::new(master.as_fd(), PollFlags::POLLIN)];
+
+            poll(&mut fds, PollTimeout::ZERO)?;
+
+            fds[0].revents().unwrap_or(PollFlags::empty())
+        };
+
+        if !master_events.intersects(PollFlags::POLLIN | PollFlags::POLLHUP | PollFlags::POLLERR) {
+            return Ok(());
+        }
+
+        match master.read(buffer) {
+            Ok(0) => return Ok(()),
+            Ok(read) => out.write_all(&buffer[..read])?,
+            Err(err) if err.raw_os_error() == Some(libc::EIO) => return Ok(()),
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 /// Foreground console state. On drop it drains the PTY->stdout relay (so the last output is not
 /// lost) and restores the terminal, so hold it for the whole lifetime — never bind it to `_`.
 struct ConsoleBridge {
     raw: Option<RawTerminalGuard>,
-    output: Option<JoinHandle<()>>,
+    output: Option<OutputRelay>,
     // A dup of the PTY master kept so SIGWINCH can resize the container terminal.
     resize: OwnedFd,
 }
 
 impl ConsoleBridge {
     /// Propagate the host terminal's current window size to the container PTY master.
-    fn resize_to_host(&self) {
+    /// Does nothing when the host stdin is not a TTY (there is no size to propagate).
+    fn resize_to_host(&self) -> Result<()> {
         let stdin = io::stdin();
         if !unistd::isatty(stdin.as_raw_fd()).unwrap_or(false) {
-            return;
+            return Ok(());
         }
 
         let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
         if unsafe { libc::ioctl(stdin.as_raw_fd(), libc::TIOCGWINSZ, &mut ws) } < 0 {
-            return;
+            return Err(io::Error::last_os_error())
+                .with_context(|| "failed to get host terminal size");
         }
-        unsafe { libc::ioctl(self.resize.as_raw_fd(), libc::TIOCSWINSZ, &ws) };
+        if unsafe { libc::ioctl(self.resize.as_raw_fd(), libc::TIOCSWINSZ, &ws) } < 0 {
+            return Err(io::Error::last_os_error())
+                .with_context(|| "failed to set container pty size");
+        }
+
+        Ok(())
     }
 }
 
 impl Drop for ConsoleBridge {
     fn drop(&mut self) {
-        // Restore the terminal first so a stuck relay cannot leave it in raw mode.
+        // Restore the host terminal before waiting for the output relay to finish.
         drop(self.raw.take());
-        // The relay ends when every PTY slave closes (container exit) and the master read hits EIO.
-        if let Some(output) = self.output.take() {
-            let _ = output.join();
-        }
+        // Dropping the relay signals its eventfd, drains queued output, and joins its thread.
+        drop(self.output.take());
     }
 }
 
 /// With a PTY master, raw-mode the host terminal and bridge host stdio <-> the PTY.
-fn attach_console(master: Option<OwnedFd>) -> Result<Option<ConsoleBridge>> {
+fn setup_console_bridge(master: Option<OwnedFd>) -> Result<Option<ConsoleBridge>> {
     match master {
         Some(master) => {
             let raw = RawTerminalGuard::new()?;
@@ -127,7 +224,7 @@ fn attach_console(master: Option<OwnedFd>) -> Result<Option<ConsoleBridge>> {
 // youki main process also forwards most of the signals to the container init
 // process.
 #[tracing::instrument(level = "trace")]
-pub(crate) fn handle_foreground(init_pid: Pid, pty_master_fd: Option<OwnedFd>) -> Result<i32> {
+pub(crate) fn handle_foreground(init_pid: Pid, foreground_pty_fd: Option<OwnedFd>) -> Result<i32> {
     tracing::trace!("waiting for container init process to exit");
 
     // We mask all signals here and forward most of the signals to the container
@@ -138,9 +235,12 @@ pub(crate) fn handle_foreground(init_pid: Pid, pty_master_fd: Option<OwnedFd>) -
         .with_context(|| "failed to call pthread_sigmask")?;
 
     // With a PTY master, raw-mode the host terminal (restored on drop) and bridge stdio.
-    let console = attach_console(pty_master_fd)?;
+    let console = setup_console_bridge(foreground_pty_fd)?;
     if let Some(console) = &console {
-        console.resize_to_host();
+        // Resize failure is not fatal; the container just keeps its default size.
+        let _ = console.resize_to_host().map_err(|err| {
+            tracing::warn!(?err, "failed to resize container terminal");
+        });
     }
 
     if let Some(status) = reap_children(init_pid)? {
@@ -167,7 +267,10 @@ pub(crate) fn handle_foreground(init_pid: Pid, pty_master_fd: Option<OwnedFd>) -
             }
             signal::SIGWINCH => {
                 if let Some(console) = &console {
-                    console.resize_to_host();
+                    // Resize failure is not fatal; the container just keeps its old size.
+                    let _ = console.resize_to_host().map_err(|err| {
+                        tracing::warn!(?err, "failed to resize container terminal");
+                    });
                 }
             }
             signal => {

--- a/crates/youki/src/commands/foreground.rs
+++ b/crates/youki/src/commands/foreground.rs
@@ -300,7 +300,7 @@ fn reap_children(init_pid: Pid) -> Result<Option<i32>> {
             }
             WaitStatus::Signaled(pid, signal, _) => {
                 if pid.eq(&init_pid) {
-                    return Ok(Some(signal as i32));
+                    return Ok(Some(128 + signal as i32));
                 }
 
                 // Else, some random child process exited, ignoring...
@@ -460,6 +460,45 @@ mod tests {
                 };
             }
         };
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reap_children_signal_exit_code() -> Result<()> {
+        // Isolate the reaped process from the test harness: P0 runs the test,
+        // P1 calls reap_children, and P2 is terminated by SIGKILL.
+        match unsafe { unistd::fork()? } {
+            unistd::ForkResult::Parent { child } => {
+                assert_eq!(
+                    wait::waitpid(child, None)?,
+                    WaitStatus::Exited(child, 128 + SIGKILL as i32)
+                );
+            }
+            unistd::ForkResult::Child => match unsafe { unistd::fork() } {
+                Ok(unistd::ForkResult::Parent { child }) => {
+                    if kill(child, SIGKILL).is_err() {
+                        std::process::exit(255);
+                    }
+
+                    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+                    loop {
+                        match reap_children(child) {
+                            Ok(Some(status)) => std::process::exit(status),
+                            Ok(None) if std::time::Instant::now() < deadline => {
+                                std::thread::sleep(Duration::from_millis(10));
+                            }
+                            _ => std::process::exit(255),
+                        }
+                    }
+                }
+                Ok(unistd::ForkResult::Child) => {
+                    std::thread::sleep(Duration::from_secs(30));
+                    std::process::exit(0);
+                }
+                Err(_) => std::process::exit(255),
+            },
+        }
 
         Ok(())
     }

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod delete;
 pub mod events;
 pub mod exec;
 pub mod features;
+pub(crate) mod foreground;
 pub mod info;
 pub mod kill;
 pub mod list;

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -4,26 +4,24 @@ use anyhow::{Context, Result};
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::syscall::syscall::SyscallType;
 use liboci_cli::Run;
-use nix::sys::signal::{self, kill};
-use nix::sys::signalfd::SigSet;
-use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
-use nix::unistd::Pid;
 
+use crate::commands::foreground;
 use crate::workload::executor::default_executor;
 
 pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
-    let mut container = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
-        .with_executor(default_executor())
-        .with_pid_file(args.pid_file.as_ref())?
-        .with_console_socket(args.console_socket.as_ref())
-        .with_root_path(root_path)?
-        .with_preserved_fds(args.preserve_fds)
-        .validate_id()?
-        .as_init(&args.bundle)
-        .with_systemd(systemd_cgroup)
-        .with_detach(args.detach)
-        .with_no_pivot(args.no_pivot)
-        .build()?;
+    let (mut container, pty_master_fd) =
+        ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
+            .with_executor(default_executor())
+            .with_pid_file(args.pid_file.as_ref())?
+            .with_console_socket(args.console_socket.as_ref())
+            .with_root_path(root_path)?
+            .with_preserved_fds(args.preserve_fds)
+            .validate_id()?
+            .as_init(&args.bundle)
+            .with_systemd(systemd_cgroup)
+            .with_detach(args.detach)
+            .with_no_pivot(args.no_pivot)
+            .build()?;
 
     container
         .start()
@@ -40,181 +38,9 @@ pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
         container.pid().is_some(),
         "expects a container init pid in the container state"
     );
-    let foreground_result = handle_foreground(container.pid().unwrap());
+    let foreground_result = foreground::handle_foreground(container.pid().unwrap(), pty_master_fd);
     // execute the destruction action after the container finishes running
     container.delete(true)?;
     // return result
     foreground_result
-}
-
-// handle_foreground will match the `runc` behavior running the foreground mode.
-// The youki main process will wait and reap the container init process. The
-// youki main process also forwards most of the signals to the container init
-// process.
-#[tracing::instrument(level = "trace")]
-fn handle_foreground(init_pid: Pid) -> Result<i32> {
-    tracing::trace!("waiting for container init process to exit");
-    // We mask all signals here and forward most of the signals to the container
-    // init process.
-    let signal_set = SigSet::all();
-    signal_set
-        .thread_block()
-        .with_context(|| "failed to call pthread_sigmask")?;
-    loop {
-        match signal_set
-            .wait()
-            .with_context(|| "failed to call sigwait")?
-        {
-            signal::SIGCHLD => {
-                // Reap all child until either container init process exits or
-                // no more child to be reaped. Once the container init process
-                // exits we can then return.
-                tracing::trace!("reaping child processes");
-                loop {
-                    match waitpid(None, Some(WaitPidFlag::WNOHANG))? {
-                        WaitStatus::Exited(pid, status) => {
-                            if pid.eq(&init_pid) {
-                                return Ok(status);
-                            }
-
-                            // Else, some random child process exited, ignoring...
-                        }
-                        WaitStatus::Signaled(pid, signal, _) => {
-                            if pid.eq(&init_pid) {
-                                return Ok(signal as i32);
-                            }
-
-                            // Else, some random child process exited, ignoring...
-                        }
-                        WaitStatus::StillAlive => {
-                            // No more child to reap.
-                            break;
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            signal::SIGURG => {
-                // In `runc`, SIGURG is used by go runtime and should not be forwarded to
-                // the container process. Here, we just ignore the signal.
-            }
-            signal::SIGWINCH => {
-                // TODO: resize the terminal
-            }
-            signal => {
-                tracing::trace!(?signal, "forwarding signal");
-                // There is nothing we can do if we fail to forward the signal.
-                let _ = kill(init_pid, Some(signal)).map_err(|err| {
-                    tracing::warn!(
-                        ?err,
-                        ?signal,
-                        "failed to forward signal to container init process",
-                    );
-                });
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use nix::sys::signal::Signal::SIGINT;
-    use nix::sys::wait;
-    use nix::unistd;
-
-    use super::*;
-
-    #[test]
-    fn test_foreground_forward_sig() -> Result<()> {
-        // To set up the test correctly, we need to run the test in dedicated
-        // process, so the rust unit test runtime and other unit tests will not
-        // mess with the signal handling. We use `sigkill` as a simple way to
-        // make sure the signal is properly forwarded. In this test, P0 is the
-        // rust process that runs this unit test (in a thread). P1 mocks youki
-        // main and P2 mocks the container init process
-        match unsafe { unistd::fork()? } {
-            unistd::ForkResult::Parent { child } => {
-                // Inside P0
-                //
-                // We need to make sure that the child process has entered into
-                // the signal forwarding loops. There is no way to 100% sync
-                // that the child has executed the for loop waiting to forward
-                // the signal. There are sync mechanisms with condvar or
-                // channels to make it as close to calling the handle_foreground
-                // function as possible, but still have a tiny (highly unlikely
-                // but probable) window that a race can still happen. So instead
-                // we just wait for 1 second for everything to settle. In
-                // general, I don't like sleep in tests to avoid race condition,
-                // but I'd rather not over-engineer this now. We can revisit
-                // this later if the test becomes flaky.
-                std::thread::sleep(Duration::from_secs(1));
-                // Send the `sigint` signal to P1 who will forward the signal
-                // to P2. P2 will then exit and send a sigchld to P1. P1 will
-                // then reap P2 and exits. In P0, we can then reap P1.
-                kill(child, SIGINT)?;
-                wait::waitpid(child, None)?;
-            }
-            unistd::ForkResult::Child => {
-                // Inside P1. Fork P2 as mock container init process and run
-                // signal handler process inside.
-                match unsafe { unistd::fork()? } {
-                    unistd::ForkResult::Parent { child } => {
-                        // Inside P1.
-                        let _ = handle_foreground(child).map_err(|err| {
-                            // Since we are in a child process, we want to use trace to log the error.
-                            let _ = tracing_subscriber::fmt()
-                                .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-                                .try_init();
-                            tracing::error!(?err, "failed to handle foreground");
-                            err
-                        });
-                        std::process::exit(0);
-                    }
-                    unistd::ForkResult::Child => {
-                        let mut signal_set = SigSet::empty();
-                        signal_set.add(SIGINT);
-                        signal_set.thread_block()?;
-                        signal_set.wait()?;
-                        std::process::exit(0);
-                    }
-                };
-            }
-        };
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_foreground_exit() -> Result<()> {
-        // The setup is similar to `handle_foreground`, but instead of
-        // forwarding signal, the container init process will exit. Again, we
-        // use `sleep` to simulate the conditions to avoid fine grained
-        // synchronization for now.
-        match unsafe { unistd::fork()? } {
-            unistd::ForkResult::Parent { child } => {
-                // Inside P0
-                std::thread::sleep(Duration::from_secs(1));
-                wait::waitpid(child, None)?;
-            }
-            unistd::ForkResult::Child => {
-                // Inside P1. Fork P2 as mock container init process and run
-                // signal handler process inside.
-                match unsafe { unistd::fork()? } {
-                    unistd::ForkResult::Parent { child } => {
-                        // Inside P1.
-                        handle_foreground(child)?;
-                        wait::waitpid(child, None)?;
-                    }
-                    unistd::ForkResult::Child => {
-                        // Inside P2. The process exits after 1 second.
-                        std::thread::sleep(Duration::from_secs(1));
-                    }
-                };
-            }
-        };
-
-        Ok(())
-    }
 }

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -9,7 +9,7 @@ use crate::commands::foreground;
 use crate::workload::executor::default_executor;
 
 pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
-    let (mut container, pty_master_fd) =
+    let (mut container, foreground_pty_fd) =
         ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
             .with_executor(default_executor())
             .with_pid_file(args.pid_file.as_ref())?
@@ -38,7 +38,8 @@ pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
         container.pid().is_some(),
         "expects a container init pid in the container state"
     );
-    let foreground_result = foreground::handle_foreground(container.pid().unwrap(), pty_master_fd);
+    let foreground_result =
+        foreground::handle_foreground(container.pid().unwrap(), foreground_pty_fd);
     // execute the destruction action after the container finishes running
     container.delete(true)?;
     // return result

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -56,6 +56,7 @@ use crate::tests::scheduler::get_scheduler_test;
 use crate::tests::seccomp::get_seccomp_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::sysctl::get_sysctl_test;
+use crate::tests::terminal::get_terminal_test;
 use crate::tests::tlb::get_tlb_test;
 use crate::tests::uid_mappings::get_uid_mappings_test;
 use crate::tests::update::get_update_test;
@@ -179,6 +180,7 @@ fn main() -> Result<()> {
     let personality = get_personality_test();
     let prohibit_symlink = get_prohibit_symlink_test();
     let net_devices = get_net_devices_test();
+    let terminal = get_terminal_test();
     let checkpoint_restore = get_checkpoint_restore_tests();
     let update = get_update_test();
 
@@ -238,6 +240,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(personality));
     tm.add_test_group(Box::new(prohibit_symlink));
     tm.add_test_group(Box::new(io_priority_test));
+    tm.add_test_group(Box::new(terminal));
     tm.add_test_group(Box::new(checkpoint_restore));
     tm.add_test_group(Box::new(update));
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -57,6 +57,7 @@ use crate::tests::scheduler::get_scheduler_test;
 use crate::tests::seccomp::get_seccomp_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::sysctl::get_sysctl_test;
+use crate::tests::terminal::get_terminal_test;
 use crate::tests::time_ns::get_time_ns_test;
 use crate::tests::tlb::get_tlb_test;
 use crate::tests::uid_mappings::get_uid_mappings_test;
@@ -182,6 +183,7 @@ fn main() -> Result<()> {
     let personality = get_personality_test();
     let prohibit_symlink = get_prohibit_symlink_test();
     let net_devices = get_net_devices_test();
+    let terminal = get_terminal_test();
     let checkpoint_restore = get_checkpoint_restore_tests();
     let update = get_update_test();
     let time_ns = get_time_ns_test();
@@ -243,6 +245,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(personality));
     tm.add_test_group(Box::new(prohibit_symlink));
     tm.add_test_group(Box::new(io_priority_test));
+    tm.add_test_group(Box::new(terminal));
     tm.add_test_group(Box::new(checkpoint_restore));
     tm.add_test_group(Box::new(update));
     tm.add_test_group(Box::new(time_ns));

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -46,6 +46,7 @@ pub mod scheduler;
 pub mod seccomp;
 pub mod seccomp_notify;
 pub mod sysctl;
+pub mod terminal;
 pub mod tlb;
 pub mod uid_mappings;
 pub mod update;

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -47,6 +47,7 @@ pub mod scheduler;
 pub mod seccomp;
 pub mod seccomp_notify;
 pub mod sysctl;
+pub mod terminal;
 pub mod time_ns;
 pub mod tlb;
 pub mod uid_mappings;

--- a/tests/contest/contest/src/tests/terminal/exec_tests.rs
+++ b/tests/contest/contest/src/tests/terminal/exec_tests.rs
@@ -1,0 +1,252 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
+use serde_json::json;
+use test_framework::{TestResult, test_result};
+
+use super::{drain_master, poll_size_script, saw_line, sized_pty, spawn_on_pty, wait_timeout};
+use crate::utils::test_utils::{build_exec_command, check_container_created};
+use crate::utils::{start_container, test_outside_container};
+
+// The exec tests keep a long-running container around and exec into it.
+fn sleeper_spec() -> Spec {
+    SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["sleep".to_string(), "1000".to_string()])
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+// foreground `youki exec` with a terminal=true process.json and no --console-socket must bridge
+// the PTY master to the caller's stdio (like run), so the exec'd process's tty output is captured.
+pub(crate) fn terminal_exec_no_console_socket_test() -> TestResult {
+    test_outside_container(&sleeper_spec(), &|data| {
+        test_result!(check_container_created(&data));
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start = start_container(id, dir).unwrap().wait().unwrap();
+        if !start.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let process_json = json!({
+            "terminal": true,
+            "cwd": "/",
+            "args": ["sh", "-c", "if [ -t 1 ]; then echo TTY; else echo NOT_TTY; fi"],
+            "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+            "user": { "uid": 0, "gid": 0 }
+        });
+        let process_path = dir.join("terminal-process.json");
+        if let Err(e) = fs::write(
+            &process_path,
+            serde_json::to_vec_pretty(&process_json).unwrap(),
+        ) {
+            return TestResult::Failed(anyhow!("failed to write process.json: {e}"));
+        }
+
+        let pty = match sized_pty(24, 80) {
+            Ok(pty) => pty,
+            Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+        };
+        let mut child = match spawn_on_pty(
+            build_exec_command(id, dir, &[OsStr::new("")], Some(&process_path), &[]),
+            pty.slave,
+        ) {
+            Ok(child) => child,
+            Err(e) => return TestResult::Failed(anyhow!("failed to spawn exec: {e:?}")),
+        };
+
+        let reader = drain_master(pty.master);
+        let status = wait_timeout(&mut child, Duration::from_secs(30));
+        let output = reader.join().unwrap_or_default();
+
+        if saw_line(&output, "NOT_TTY") {
+            return TestResult::Failed(anyhow!("exec stdout was not a tty despite terminal=true"));
+        }
+        if saw_line(&output, "TTY") {
+            TestResult::Passed
+        } else {
+            TestResult::Failed(anyhow!(
+                "exec terminal output not bridged to caller: output={:?} status={:?}",
+                output,
+                status
+            ))
+        }
+    })
+}
+
+// `youki exec -t/--tty` without a --process file must allocate a PTY, like runc.
+pub(crate) fn terminal_exec_tty_flag_test() -> TestResult {
+    test_outside_container(&sleeper_spec(), &|data| {
+        test_result!(check_container_created(&data));
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start = start_container(id, dir).unwrap().wait().unwrap();
+        if !start.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let pty = match sized_pty(24, 80) {
+            Ok(pty) => pty,
+            Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+        };
+        let mut child = match spawn_on_pty(
+            build_exec_command(
+                id,
+                dir,
+                &[
+                    "--tty",
+                    "sh",
+                    "-c",
+                    "if [ -t 1 ]; then echo TTY; else echo NOT_TTY; fi",
+                ],
+                None,
+                &[],
+            ),
+            pty.slave,
+        ) {
+            Ok(child) => child,
+            Err(e) => return TestResult::Failed(anyhow!("failed to spawn exec: {e:?}")),
+        };
+
+        let reader = drain_master(pty.master);
+        let status = wait_timeout(&mut child, Duration::from_secs(30));
+        let output = reader.join().unwrap_or_default();
+
+        if saw_line(&output, "NOT_TTY") {
+            return TestResult::Failed(anyhow!("exec --tty did not allocate a terminal"));
+        }
+        if saw_line(&output, "TTY") {
+            TestResult::Passed
+        } else {
+            TestResult::Failed(anyhow!(
+                "no tty marker in exec --tty output: output={:?} status={:?}",
+                output,
+                status
+            ))
+        }
+    })
+}
+
+// When --process is given, runc ignores -t/--tty entirely: the process.json decides.
+pub(crate) fn terminal_exec_tty_flag_with_process_json_test() -> TestResult {
+    test_outside_container(&sleeper_spec(), &|data| {
+        test_result!(check_container_created(&data));
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start = start_container(id, dir).unwrap().wait().unwrap();
+        if !start.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        // terminal is absent (= false) in the process.json; --tty must not override it.
+        let process_json = json!({
+            "cwd": "/",
+            "args": ["sh", "-c", "if [ -t 1 ]; then echo TTY; else echo NOT_TTY; fi"],
+            "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+            "user": { "uid": 0, "gid": 0 }
+        });
+        let process_path = dir.join("tty-flag-process.json");
+        if let Err(e) = fs::write(
+            &process_path,
+            serde_json::to_vec_pretty(&process_json).unwrap(),
+        ) {
+            return TestResult::Failed(anyhow!("failed to write process.json: {e}"));
+        }
+
+        let output =
+            match build_exec_command(id, dir, &[OsStr::new("--tty")], Some(&process_path), &[])
+                .stdin(Stdio::null())
+                .output()
+            {
+                Ok(o) => o,
+                Err(e) => return TestResult::Failed(anyhow!("failed to run exec: {e:?}")),
+            };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if saw_line(&stdout, "NOT_TTY") {
+            TestResult::Passed
+        } else {
+            TestResult::Failed(anyhow!(
+                "--tty must be ignored when --process is given (runc semantics): \
+                 stdout={:?} status={:?} stderr={}",
+                stdout,
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            ))
+        }
+    })
+}
+
+// Foreground exec must propagate the host terminal size to the exec'd PTY (like runc's
+// initial resize). We give youki a real tty of a known size and read `stty size` inside.
+pub(crate) fn terminal_exec_terminal_size_test() -> TestResult {
+    test_outside_container(&sleeper_spec(), &|data| {
+        test_result!(check_container_created(&data));
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start = start_container(id, dir).unwrap().wait().unwrap();
+        if !start.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let process_json = json!({
+            "terminal": true,
+            "cwd": "/",
+            "args": ["sh", "-c", poll_size_script("EXEC_SIZE", "19 73")],
+            "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+            "user": { "uid": 0, "gid": 0 }
+        });
+        let process_path = dir.join("terminal-size-process.json");
+        if let Err(e) = fs::write(
+            &process_path,
+            serde_json::to_vec_pretty(&process_json).unwrap(),
+        ) {
+            return TestResult::Failed(anyhow!("failed to write process.json: {e}"));
+        }
+
+        let pty = match sized_pty(19, 73) {
+            Ok(pty) => pty,
+            Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+        };
+        let mut child = match spawn_on_pty(
+            build_exec_command(id, dir, &[OsStr::new("")], Some(&process_path), &[]),
+            pty.slave,
+        ) {
+            Ok(child) => child,
+            Err(e) => return TestResult::Failed(anyhow!("failed to spawn exec: {e:?}")),
+        };
+
+        let reader = drain_master(pty.master);
+        let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+            Ok(status) => status,
+            Err(e) => return TestResult::Failed(anyhow!("failed to wait for exec: {e:?}")),
+        };
+        let output = reader.join().unwrap_or_default();
+
+        let marker = "EXEC_SIZE=19 73";
+        if saw_line(&output, marker) {
+            TestResult::Passed
+        } else {
+            TestResult::Failed(anyhow!(
+                "host terminal size (19x73) not propagated to the exec PTY: \
+                 expected {:?}, output={:?} status={:?}",
+                marker,
+                output,
+                status
+            ))
+        }
+    })
+}

--- a/tests/contest/contest/src/tests/terminal/exec_tests.rs
+++ b/tests/contest/contest/src/tests/terminal/exec_tests.rs
@@ -66,7 +66,10 @@ pub(crate) fn terminal_exec_no_console_socket_test() -> TestResult {
         };
 
         let reader = drain_master(pty.master);
-        let status = wait_timeout(&mut child, Duration::from_secs(30));
+        let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+            Ok(status) => status,
+            Err(e) => return TestResult::Failed(anyhow!("failed to wait for exec: {e:?}")),
+        };
         let output = reader.join().unwrap_or_default();
 
         if saw_line(&output, "NOT_TTY") {
@@ -120,7 +123,10 @@ pub(crate) fn terminal_exec_tty_flag_test() -> TestResult {
         };
 
         let reader = drain_master(pty.master);
-        let status = wait_timeout(&mut child, Duration::from_secs(30));
+        let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+            Ok(status) => status,
+            Err(e) => return TestResult::Failed(anyhow!("failed to wait for exec: {e:?}")),
+        };
         let output = reader.join().unwrap_or_default();
 
         if saw_line(&output, "NOT_TTY") {
@@ -247,6 +253,73 @@ pub(crate) fn terminal_exec_terminal_size_test() -> TestResult {
                 output,
                 status
             ))
+        }
+    })
+}
+
+// Once the exec'd process exits, foreground `youki exec` must return even when a descendant keeps
+// the PTY slave open. Otherwise the PTY-to-stdout relay waits forever and youki never exits.
+pub(crate) fn terminal_exec_background_process_does_not_block_test() -> TestResult {
+    test_outside_container(&sleeper_spec(), &|data| {
+        test_result!(check_container_created(&data));
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start = start_container(id, dir).unwrap().wait().unwrap();
+        if !start.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let process_json = json!({
+            "terminal": true,
+            "cwd": "/",
+            // Ignore SIGHUP so the background process survives after its parent shell exits,
+            // while retaining the exec PTY slave on its standard streams.
+            "args": ["sh", "-c", "trap '' HUP; sleep 30 & echo EXEC_DONE"],
+            "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+            "user": { "uid": 0, "gid": 0 }
+        });
+        let process_path = dir.join("terminal-background-process.json");
+        if let Err(e) = fs::write(
+            &process_path,
+            serde_json::to_vec_pretty(&process_json).unwrap(),
+        ) {
+            return TestResult::Failed(anyhow!("failed to write process.json: {e}"));
+        }
+
+        let pty = match sized_pty(24, 80) {
+            Ok(pty) => pty,
+            Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+        };
+        let mut child = match spawn_on_pty(
+            build_exec_command(id, dir, &[OsStr::new("")], Some(&process_path), &[]),
+            pty.slave,
+        ) {
+            Ok(child) => child,
+            Err(e) => return TestResult::Failed(anyhow!("failed to spawn exec: {e:?}")),
+        };
+
+        let reader = drain_master(pty.master);
+        let status = wait_timeout(&mut child, Duration::from_secs(5));
+        let output = reader.join().unwrap_or_default();
+
+        let status = match status {
+            Ok(status) => status,
+            Err(e) => {
+                return TestResult::Failed(anyhow!(
+                    "foreground exec did not exit after its process exited: {e:?}; output={output:?}"
+                ));
+            }
+        };
+        if !status.success() {
+            return TestResult::Failed(anyhow!(
+                "foreground exec failed with status {status:?}: output={output:?}"
+            ));
+        }
+        if saw_line(&output, "EXEC_DONE") {
+            TestResult::Passed
+        } else {
+            TestResult::Failed(anyhow!("missing exec completion marker: output={output:?}"))
         }
     })
 }

--- a/tests/contest/contest/src/tests/terminal/mod.rs
+++ b/tests/contest/contest/src/tests/terminal/mod.rs
@@ -1,0 +1,257 @@
+mod exec_tests;
+mod run_tests;
+
+use std::fs;
+use std::io::{ErrorKind, IoSliceMut, Read};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixListener;
+use std::path::Path;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, anyhow};
+use nix::fcntl::{FcntlArg, OFlag, fcntl};
+use nix::libc;
+use nix::pty::{OpenptyResult, Winsize, openpty};
+use nix::sys::socket::{ControlMessageOwned, MsgFlags, recvmsg};
+use oci_spec::runtime::{BoxBuilder, ProcessBuilder, Spec, SpecBuilder};
+use test_framework::{Test, TestGroup};
+
+use crate::utils::get_runtime_path;
+
+fn terminal_spec(command: &str) -> Spec {
+    SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .terminal(true)
+                .args(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    command.to_string(),
+                ])
+                .build()
+                .expect("error in creating process config"),
+        )
+        .build()
+        .unwrap()
+}
+
+fn console_size_spec(command: &str, height: u64, width: u64) -> Spec {
+    SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .terminal(true)
+                .console_size(
+                    BoxBuilder::default()
+                        .height(height)
+                        .width(width)
+                        .build()
+                        .expect("error in creating console size"),
+                )
+                .args(vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    command.to_string(),
+                ])
+                .build()
+                .expect("error in creating process config"),
+        )
+        .build()
+        .unwrap()
+}
+
+fn runtime_command(bundle_root: &Path, subcommand: &str) -> Command {
+    let mut command = Command::new(get_runtime_path());
+    command
+        .arg("--root")
+        .arg(bundle_root.join("runtime"))
+        .arg(subcommand);
+    command
+}
+
+fn run_command(bundle_root: &Path, id: &str) -> Command {
+    let mut command = runtime_command(bundle_root, "run");
+    command
+        .arg(id)
+        .arg("--bundle")
+        .arg(bundle_root.join("bundle"));
+    command
+}
+
+// PTY output uses \r\n (doubled when it crosses two PTYs), so trim trailing \r.
+fn saw_line(stdout: &str, marker: &str) -> bool {
+    stdout
+        .lines()
+        .any(|line| line.trim_end_matches('\r') == marker)
+}
+
+// Shell that polls `stty size` (~5s) until `want` appears, then echoes "<marker>=<last size>".
+// The resize races with the container's startup, and on a 0x0 PTY busybox `stty size`
+// prints nothing (GNU prints "0 0"), hence the polling.
+fn poll_size_script(marker: &str, want: &str) -> String {
+    format!(
+        "i=0; s=; while [ $i -lt 50 ]; do \
+         s=$(stty size 2>/dev/null); \
+         [ \"$s\" = \"{want}\" ] && break; \
+         sleep 0.1 2>/dev/null || sleep 1; i=$((i+1)); done; \
+         echo \"{marker}=$s\""
+    )
+}
+
+fn sized_pty(rows: u16, cols: u16) -> nix::Result<OpenptyResult> {
+    let winsize = Some(Winsize {
+        ws_row: rows,
+        ws_col: cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    });
+    openpty(&winsize, None)
+}
+
+fn set_winsize(fd: &impl AsRawFd, rows: u16, cols: u16) {
+    let ws = libc::winsize {
+        ws_row: rows,
+        ws_col: cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    unsafe { libc::ioctl(fd.as_raw_fd(), libc::TIOCSWINSZ, &ws) };
+}
+
+// Spawn with all stdio on the pty slave. The slave is consumed so that no slave fd
+// stays behind in the test process and the master read can hit EIO after exit.
+fn spawn_on_pty(mut command: Command, slave: OwnedFd) -> std::io::Result<Child> {
+    let stdin = slave.try_clone()?;
+    let stdout = slave.try_clone()?;
+    command
+        .stdin(Stdio::from(stdin))
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(slave))
+        .spawn()
+}
+
+// Kill the child if it does not exit in time so a regression fails instead of hanging the suite.
+fn wait_timeout(child: &mut Child, timeout: Duration) -> std::io::Result<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            return child.wait();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+// Receive the PTY master sent by the runtime over the console socket (SCM_RIGHTS).
+fn recv_pty_master(listener: &UnixListener) -> Result<OwnedFd> {
+    let (stream, _) = listener.accept()?;
+    let mut buf = [0u8; 4096];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsg_space = nix::cmsg_space!([RawFd; 1]);
+    let msg = recvmsg::<()>(
+        stream.as_raw_fd(),
+        &mut iov,
+        Some(&mut cmsg_space),
+        MsgFlags::empty(),
+    )?;
+    for cmsg in msg.cmsgs()? {
+        if let ControlMessageOwned::ScmRights(fds) = cmsg
+            && let Some(&fd) = fds.first()
+        {
+            // SAFETY: the fd was just received via SCM_RIGHTS, so we own it.
+            return Ok(unsafe { OwnedFd::from_raw_fd(fd) });
+        }
+    }
+    Err(anyhow!("no fd received on the console socket"))
+}
+
+// Read the master until EOF or the deadline (the container may stay alive on failure).
+fn read_master_for(master: OwnedFd, timeout: Duration) -> String {
+    let _ = fcntl(master.as_raw_fd(), FcntlArg::F_SETFL(OFlag::O_NONBLOCK));
+    let mut file = fs::File::from(master);
+    let deadline = Instant::now() + timeout;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    while Instant::now() < deadline {
+        match file.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => break,
+        }
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+// Drain the PTY master until every slave fd closes (the master read then hits EIO).
+fn drain_master(master: OwnedFd) -> JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut master = fs::File::from(master);
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            match master.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            }
+        }
+        String::from_utf8_lossy(&buf).into_owned()
+    })
+}
+
+pub fn get_terminal_test() -> TestGroup {
+    let mut tg = TestGroup::new("terminal");
+    tg.add(vec![
+        Box::new(Test::new(
+            "terminal_no_console_socket",
+            Box::new(run_tests::terminal_no_console_socket_test),
+        )),
+        Box::new(Test::new(
+            "terminal_stdin_bridge",
+            Box::new(run_tests::terminal_stdin_bridge_test),
+        )),
+        Box::new(Test::new(
+            "terminal_console_size",
+            Box::new(run_tests::terminal_console_size_test),
+        )),
+        Box::new(Test::new(
+            "terminal_run_sigwinch",
+            Box::new(run_tests::terminal_run_sigwinch_test),
+        )),
+        Box::new(Test::new(
+            "terminal_run_exit_code",
+            Box::new(run_tests::terminal_run_exit_code_test),
+        )),
+        Box::new(Test::new(
+            "terminal_raw_restore",
+            Box::new(run_tests::terminal_raw_restore_test),
+        )),
+        Box::new(Test::new(
+            "terminal_large_output",
+            Box::new(run_tests::terminal_large_output_test),
+        )),
+        Box::new(Test::new(
+            "terminal_exec_no_console_socket",
+            Box::new(exec_tests::terminal_exec_no_console_socket_test),
+        )),
+        Box::new(Test::new(
+            "terminal_exec_terminal_size",
+            Box::new(exec_tests::terminal_exec_terminal_size_test),
+        )),
+        Box::new(Test::new(
+            "terminal_exec_tty_flag",
+            Box::new(exec_tests::terminal_exec_tty_flag_test),
+        )),
+        Box::new(Test::new(
+            "terminal_exec_tty_flag_with_process_json",
+            Box::new(exec_tests::terminal_exec_tty_flag_with_process_json_test),
+        )),
+    ]);
+    tg
+}

--- a/tests/contest/contest/src/tests/terminal/mod.rs
+++ b/tests/contest/contest/src/tests/terminal/mod.rs
@@ -18,7 +18,7 @@ use nix::sys::socket::{ControlMessageOwned, MsgFlags, recvmsg};
 use oci_spec::runtime::{BoxBuilder, ProcessBuilder, Spec, SpecBuilder};
 use test_framework::{Test, TestGroup};
 
-use crate::utils::get_runtime_path;
+use crate::utils::test_utils;
 
 fn terminal_spec(command: &str) -> Spec {
     SpecBuilder::default()
@@ -62,11 +62,8 @@ fn console_size_spec(command: &str, height: u64, width: u64) -> Spec {
 }
 
 fn runtime_command(bundle_root: &Path, subcommand: &str) -> Command {
-    let mut command = Command::new(get_runtime_path());
-    command
-        .arg("--root")
-        .arg(bundle_root.join("runtime"))
-        .arg(subcommand);
+    let mut command = test_utils::runtime_command(bundle_root);
+    command.arg(subcommand);
     command
 }
 
@@ -79,11 +76,10 @@ fn run_command(bundle_root: &Path, id: &str) -> Command {
     command
 }
 
-// PTY output uses \r\n (doubled when it crosses two PTYs), so trim trailing \r.
+// The container pty runs with -onlcr (like runc), so at most a single \r\n
+// line ending remains, which str::lines() already strips.
 fn saw_line(stdout: &str, marker: &str) -> bool {
-    stdout
-        .lines()
-        .any(|line| line.trim_end_matches('\r') == marker)
+    stdout.lines().any(|line| line == marker)
 }
 
 // Shell that polls `stty size` (~5s) until `want` appears, then echoes "<marker>=<last size>".
@@ -139,8 +135,14 @@ fn wait_timeout(child: &mut Child, timeout: Duration) -> std::io::Result<ExitSta
             return Ok(status);
         }
         if Instant::now() > deadline {
-            let _ = child.kill();
-            return child.wait();
+            let kill_result = child.kill();
+            let wait_result = child.wait();
+            return Err(std::io::Error::new(
+                ErrorKind::TimedOut,
+                format!(
+                    "child did not exit within {timeout:?}; kill={kill_result:?}; wait={wait_result:?}"
+                ),
+            ));
         }
         std::thread::sleep(Duration::from_millis(100));
     }
@@ -243,6 +245,10 @@ pub fn get_terminal_test() -> TestGroup {
         Box::new(Test::new(
             "terminal_exec_terminal_size",
             Box::new(exec_tests::terminal_exec_terminal_size_test),
+        )),
+        Box::new(Test::new(
+            "terminal_exec_background_process_does_not_block",
+            Box::new(exec_tests::terminal_exec_background_process_does_not_block_test),
         )),
         Box::new(Test::new(
             "terminal_exec_tty_flag",

--- a/tests/contest/contest/src/tests/terminal/run_tests.rs
+++ b/tests/contest/contest/src/tests/terminal/run_tests.rs
@@ -1,0 +1,324 @@
+use std::fs;
+use std::io::Write;
+use std::os::unix::net::UnixListener;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use nix::sys::signal::{Signal, kill};
+use nix::sys::termios::{self, LocalFlags};
+use nix::unistd::Pid;
+use test_framework::TestResult;
+
+use super::{
+    console_size_spec, drain_master, poll_size_script, read_master_for, recv_pty_master,
+    run_command, runtime_command, saw_line, set_winsize, sized_pty, spawn_on_pty, terminal_spec,
+    wait_timeout,
+};
+use crate::utils::{generate_uuid, prepare_bundle, set_config};
+
+// process.terminal=true + no console socket => the container gets a real tty.
+// Every foreground test brings its own host pty: runc refuses to run a
+// foreground terminal container when the caller has no terminal at all.
+pub(crate) fn terminal_no_console_socket_test() -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+    set_config(
+        &bundle,
+        &terminal_spec("if [ -t 1 ]; then echo TTY; else echo NOT_TTY; fi"),
+    )
+    .unwrap();
+
+    let pty = match sized_pty(24, 80) {
+        Ok(pty) => pty,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+    };
+    let mut child = match spawn_on_pty(run_command(bundle.as_ref(), &id), pty.slave) {
+        Ok(child) => child,
+        Err(e) => return TestResult::Failed(anyhow!("failed to spawn container: {e:?}")),
+    };
+
+    let reader = drain_master(pty.master);
+    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let output = reader.join().unwrap_or_default();
+
+    if saw_line(&output, "NOT_TTY") {
+        return TestResult::Failed(anyhow!(
+            "container stdout was not a tty despite process.terminal=true"
+        ));
+    }
+    if saw_line(&output, "TTY") {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "missing tty marker: output={:?} status={:?}",
+            output,
+            status
+        ))
+    }
+}
+
+// Host input is bridged into the container's PTY: a line fed to the host pty
+// reaches the container's `read`.
+pub(crate) fn terminal_stdin_bridge_test() -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+    set_config(&bundle, &terminal_spec("read line; echo \"GOT:$line\"")).unwrap();
+
+    let pty = match sized_pty(24, 80) {
+        Ok(pty) => pty,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+    };
+    let mut child = match spawn_on_pty(run_command(bundle.as_ref(), &id), pty.slave) {
+        Ok(child) => child,
+        Err(e) => return TestResult::Failed(anyhow!("failed to spawn container: {e:?}")),
+    };
+
+    let mut writer = match pty.master.try_clone() {
+        Ok(fd) => fs::File::from(fd),
+        Err(e) => return TestResult::Failed(anyhow!("failed to dup pty master: {e}")),
+    };
+    let reader = drain_master(pty.master);
+    if let Err(e) = writer.write_all(b"hello\n") {
+        return TestResult::Failed(anyhow!("failed to write to the pty: {e:?}"));
+    }
+
+    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let output = reader.join().unwrap_or_default();
+    if saw_line(&output, "GOT:hello") {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "stdin was not bridged to the container: output={:?} status={:?}",
+            output,
+            status
+        ))
+    }
+}
+
+// process.consoleSize sets the PTY size. Checked via the console-socket path:
+// a foreground tty would immediately be resized to the host terminal size,
+// by youki and runc alike.
+pub(crate) fn terminal_console_size_test() -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+    // Non-canonical size so a stray 80x24/24x80 default cannot fake a pass.
+    let (height, width): (u64, u64) = (17, 71);
+    set_config(
+        &bundle,
+        &console_size_spec("echo \"CONSOLE_SIZE=$(stty size)\"", height, width),
+    )
+    .unwrap();
+
+    let socket_path = bundle.as_ref().join("console.sock");
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(e) => return TestResult::Failed(anyhow!("failed to bind console socket: {e}")),
+    };
+    let cleanup = || {
+        let _ = runtime_command(bundle.as_ref(), "delete")
+            .arg("-f")
+            .arg(&id)
+            .output();
+    };
+
+    let create = match runtime_command(bundle.as_ref(), "create")
+        .arg(&id)
+        .arg("--bundle")
+        .arg(bundle.as_ref().join("bundle"))
+        .arg("--console-socket")
+        .arg(&socket_path)
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) => return TestResult::Failed(anyhow!("failed to run create: {e:?}")),
+    };
+    if !create.status.success() {
+        return TestResult::Failed(anyhow!(
+            "create failed with status {:?}, stderr: {}",
+            create.status,
+            String::from_utf8_lossy(&create.stderr)
+        ));
+    }
+
+    let master = match recv_pty_master(&listener) {
+        Ok(master) => master,
+        Err(e) => {
+            cleanup();
+            return TestResult::Failed(anyhow!("failed to receive the pty master: {e}"));
+        }
+    };
+
+    let start = match runtime_command(bundle.as_ref(), "start").arg(&id).output() {
+        Ok(output) => output,
+        Err(e) => {
+            cleanup();
+            return TestResult::Failed(anyhow!("failed to run start: {e:?}"));
+        }
+    };
+    if !start.status.success() {
+        cleanup();
+        return TestResult::Failed(anyhow!(
+            "start failed with status {:?}, stderr: {}",
+            start.status,
+            String::from_utf8_lossy(&start.stderr)
+        ));
+    }
+
+    let output = read_master_for(master, Duration::from_secs(10));
+    cleanup();
+
+    let marker = format!("CONSOLE_SIZE={height} {width}");
+    if saw_line(&output, &marker) {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "process.consoleSize not applied to PTY: expected {:?} in {:?}",
+            marker,
+            output
+        ))
+    }
+}
+
+// SIGWINCH to youki must propagate the new host terminal size to the container PTY.
+pub(crate) fn terminal_run_sigwinch_test() -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+    set_config(
+        &bundle,
+        &terminal_spec(&poll_size_script("WINCH_SIZE", "31 91")),
+    )
+    .unwrap();
+
+    let pty = match sized_pty(19, 73) {
+        Ok(pty) => pty,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+    };
+    let mut child = match spawn_on_pty(run_command(bundle.as_ref(), &id), pty.slave) {
+        Ok(child) => child,
+        Err(e) => return TestResult::Failed(anyhow!("failed to spawn container: {e:?}")),
+    };
+
+    // Resize the host pty and notify youki; repeat in case the first signal
+    // fires before youki's signal mask is in place.
+    let pid = Pid::from_raw(child.id() as i32);
+    for _ in 0..3 {
+        std::thread::sleep(Duration::from_millis(700));
+        set_winsize(&pty.master, 31, 91);
+        let _ = kill(pid, Signal::SIGWINCH);
+    }
+
+    let reader = drain_master(pty.master);
+    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let output = reader.join().unwrap_or_default();
+    if saw_line(&output, "WINCH_SIZE=31 91") {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "SIGWINCH resize not propagated to the container PTY: output={:?} status={:?}",
+            output,
+            status
+        ))
+    }
+}
+
+// The container's exit status must become youki's exit status in foreground mode.
+pub(crate) fn terminal_run_exit_code_test() -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+    set_config(&bundle, &terminal_spec("exit 7")).unwrap();
+
+    let pty = match sized_pty(24, 80) {
+        Ok(pty) => pty,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+    };
+    let mut child = match spawn_on_pty(run_command(bundle.as_ref(), &id), pty.slave) {
+        Ok(child) => child,
+        Err(e) => return TestResult::Failed(anyhow!("failed to spawn container: {e:?}")),
+    };
+
+    let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+        Ok(status) => status,
+        Err(e) => return TestResult::Failed(anyhow!("failed to wait for container: {e:?}")),
+    };
+    if status.code() == Some(7) {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "expected youki to exit with the container's status 7, got {:?}",
+            status
+        ))
+    }
+}
+
+// After youki exits, the host terminal must be restored from raw mode to its original termios.
+pub(crate) fn terminal_raw_restore_test() -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+    set_config(&bundle, &terminal_spec("echo hi")).unwrap();
+
+    let pty = match sized_pty(24, 80) {
+        Ok(pty) => pty,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+    };
+    let mut child = match spawn_on_pty(run_command(bundle.as_ref(), &id), pty.slave) {
+        Ok(child) => child,
+        Err(e) => return TestResult::Failed(anyhow!("failed to spawn container: {e:?}")),
+    };
+
+    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let term = match termios::tcgetattr(&pty.master) {
+        Ok(term) => term,
+        Err(e) => return TestResult::Failed(anyhow!("failed to read back termios: {e}")),
+    };
+    if term
+        .local_flags
+        .contains(LocalFlags::ECHO | LocalFlags::ICANON)
+    {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "host terminal left in raw mode after exit: {:?} status={:?}",
+            term.local_flags,
+            status
+        ))
+    }
+}
+
+// Everything the container writes must reach the host, including the tail written right
+// before exit (larger than the 64KiB PTY buffer, so it exercises the relay and final drain).
+pub(crate) fn terminal_large_output_test() -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+    set_config(
+        &bundle,
+        &terminal_spec(
+            "awk 'BEGIN { for (i = 0; i < 102400; i++) printf \"x\"; print \"\" }'; echo BULK_DONE",
+        ),
+    )
+    .unwrap();
+
+    let pty = match sized_pty(24, 80) {
+        Ok(pty) => pty,
+        Err(e) => return TestResult::Failed(anyhow!("failed to open test pty: {e}")),
+    };
+    let mut child = match spawn_on_pty(run_command(bundle.as_ref(), &id), pty.slave) {
+        Ok(child) => child,
+        Err(e) => return TestResult::Failed(anyhow!("failed to spawn container: {e:?}")),
+    };
+
+    let reader = drain_master(pty.master);
+    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let output = reader.join().unwrap_or_default();
+
+    let xs = output.chars().filter(|&c| c == 'x').count();
+    if xs == 102400 && saw_line(&output, "BULK_DONE") {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "container output lost in the bridge: got {} of 102400 bytes, done-marker={} status={:?}",
+            xs,
+            saw_line(&output, "BULK_DONE"),
+            status
+        ))
+    }
+}

--- a/tests/contest/contest/src/tests/terminal/run_tests.rs
+++ b/tests/contest/contest/src/tests/terminal/run_tests.rs
@@ -38,7 +38,10 @@ pub(crate) fn terminal_no_console_socket_test() -> TestResult {
     };
 
     let reader = drain_master(pty.master);
-    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+        Ok(status) => status,
+        Err(e) => return TestResult::Failed(anyhow!("failed to wait for container: {e:?}")),
+    };
     let output = reader.join().unwrap_or_default();
 
     if saw_line(&output, "NOT_TTY") {
@@ -82,7 +85,10 @@ pub(crate) fn terminal_stdin_bridge_test() -> TestResult {
         return TestResult::Failed(anyhow!("failed to write to the pty: {e:?}"));
     }
 
-    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+        Ok(status) => status,
+        Err(e) => return TestResult::Failed(anyhow!("failed to wait for container: {e:?}")),
+    };
     let output = reader.join().unwrap_or_default();
     if saw_line(&output, "GOT:hello") {
         TestResult::Passed
@@ -208,7 +214,10 @@ pub(crate) fn terminal_run_sigwinch_test() -> TestResult {
     }
 
     let reader = drain_master(pty.master);
-    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+        Ok(status) => status,
+        Err(e) => return TestResult::Failed(anyhow!("failed to wait for container: {e:?}")),
+    };
     let output = reader.join().unwrap_or_default();
     if saw_line(&output, "WINCH_SIZE=31 91") {
         TestResult::Passed
@@ -265,7 +274,10 @@ pub(crate) fn terminal_raw_restore_test() -> TestResult {
         Err(e) => return TestResult::Failed(anyhow!("failed to spawn container: {e:?}")),
     };
 
-    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+        Ok(status) => status,
+        Err(e) => return TestResult::Failed(anyhow!("failed to wait for container: {e:?}")),
+    };
     let term = match termios::tcgetattr(&pty.master) {
         Ok(term) => term,
         Err(e) => return TestResult::Failed(anyhow!("failed to read back termios: {e}")),
@@ -307,7 +319,10 @@ pub(crate) fn terminal_large_output_test() -> TestResult {
     };
 
     let reader = drain_master(pty.master);
-    let status = wait_timeout(&mut child, Duration::from_secs(30));
+    let status = match wait_timeout(&mut child, Duration::from_secs(30)) {
+        Ok(status) => status,
+        Err(e) => return TestResult::Failed(anyhow!("failed to wait for container: {e:?}")),
+    };
     let output = reader.join().unwrap_or_default();
 
     let xs = output.chars().filter(|&c| c == 'x').count();

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -802,6 +802,13 @@ pub fn build_exec_command<P: AsRef<Path>>(
             command.args(&cmd);
         }
     } else {
+        // With --process, only pass through flags (the process.json holds the command).
+        for a in args {
+            let s = a.as_ref();
+            if !s.is_empty() && s.to_string_lossy().starts_with("--") {
+                command.arg(s);
+            }
+        }
         command.arg(id);
     }
 

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -328,7 +328,9 @@ pub fn resume_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
     Ok(res)
 }
 
-fn runtime_command<P: AsRef<Path>>(dir: P) -> Command {
+/// Base command to invoke the runtime under test: `<runtime> --root <dir>/runtime`,
+/// with stdout/stderr piped.
+pub fn runtime_command<P: AsRef<Path>>(dir: P) -> Command {
     let mut command = Command::new(get_runtime_path());
     command
         .stdout(Stdio::piped())

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -807,6 +807,13 @@ pub fn build_exec_command<P: AsRef<Path>>(
             command.args(&cmd);
         }
     } else {
+        // With --process, only pass through flags (the process.json holds the command).
+        for a in args {
+            let s = a.as_ref();
+            if !s.is_empty() && s.to_string_lossy().starts_with("--") {
+                command.arg(s);
+            }
+        }
         command.arg(id);
     }
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This update implements runc's foreground terminal behavior for the run and exec commands, specifically when `process.terminal` is set to true without using a console socket. In this flow, libcontainer passes the PTY master back to the youki process. The youki process then sets the host terminal to raw mode, bridges the host's standard I/O with the PTY, handles window size propagation during attach or `SIGWINCH` events, and ensures signals are properly forwarded. Additionally, the exec `-t` and `--tty` flags are now linked to process.terminal, though they are ignored if the `--process` flag is provided, consistent with runc's behavior.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->

Part of #3527 

## Additional Context
<!-- Add any other context about the pull request here -->
