### PR TITLE
test(contest): add update cpuset integration test

### DIFF
--- a/tests/contest/contest/src/tests/update/cpuset.rs
+++ b/tests/contest/contest/src/tests/update/cpuset.rs
@@ -1,0 +1,197 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+use oci_spec::runtime::{
+    LinuxCpuBuilder, LinuxResources, LinuxResourcesBuilder, ProcessBuilder, Spec, SpecBuilder,
+};
+use test_framework::{TestResult, test_result};
+
+use super::check_cgroup_value;
+use crate::utils::test_utils::check_container_created;
+use crate::utils::{start_container, test_outside_container, update_container_with_stdin};
+
+const CPUSET_MEMS_EFFECTIVE: &str = "/sys/fs/cgroup/cpuset.mems.effective";
+
+fn has_multiple_numa_nodes() -> bool {
+    fs::read_to_string(CPUSET_MEMS_EFFECTIVE)
+        .is_ok_and(|effective_mems| effective_mems.trim() != "0")
+}
+
+fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<Spec> {
+    let mut spec = SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["sleep".to_string(), "1000".to_string()])
+                .build()?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    if let Some(linux) = spec.linux_mut() {
+        linux.set_cgroups_path(Some(Path::new("/runtime-test").join(cgroup_name)));
+        linux.set_resources(resources);
+    }
+
+    Ok(spec)
+}
+
+// "update cpuset parameters via resources.CPU"
+pub(crate) fn update_cpuset_parameters_via_resources_cpu_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_cpuset_parameters_via_resources_cpu";
+
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .cpus("0")
+            .mems("0")
+            .build()
+            .context("failed to build cpu resources")
+    );
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        // check the initial values were properly set
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "0"));
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.mems", "0"));
+
+        // set CPU.Cpus to 1 in JSON format
+        let json = serde_json::json!({"cpu": {"cpus": "1"}}).to_string();
+        update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "1"));
+
+        // if NUMA is not enabled, skip this step
+        if !has_multiple_numa_nodes() {
+            return TestResult::Passed;
+        }
+
+        // set CPU.Mems to 1 in JSON format
+        let json = serde_json::json!({"cpu": {"mems": "1"}}).to_string();
+        update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.mems", "1"));
+
+        TestResult::Passed
+    })
+}
+
+// "update cpuset parameters via v2 unified map"
+pub(crate) fn update_cpuset_parameters_via_v2_unified_map_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_cpuset_parameters_via_v2_unified_map";
+
+    let unified = HashMap::from([
+        ("cpuset.cpus".to_string(), "0".to_string()),
+        ("cpuset.mems".to_string(), "0".to_string()),
+    ]);
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .unified(unified)
+            .build()
+            .context("failed to build resources spec")
+    );
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        // check the initial values were properly set
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "0"));
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.mems", "0"));
+
+        // set cpuset.cpus via v2 unified map to 1 in JSON format
+        let json = serde_json::json!({"unified": {"cpuset.cpus": "1"}}).to_string();
+        update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "1"));
+
+        // if NUMA is not enabled, skip this step
+        if !has_multiple_numa_nodes() {
+            return TestResult::Passed;
+        }
+
+        // set cpuset.mems via v2 unified map to 1 in JSON format
+        let json = serde_json::json!({"unified": {"cpuset.mems": "1"}}).to_string();
+        update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.mems", "1"));
+
+        TestResult::Passed
+    })
+}
+
+// "update cpuset cpus range via v2 unified map"
+pub(crate) fn update_cpuset_cpus_range_via_v2_unified_map_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_cpuset_cpus_range_via_v2_unified_map";
+
+    let unified = HashMap::from([("cpuset.cpus".to_string(), "0-5".to_string())]);
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .unified(unified)
+            .build()
+            .context("failed to build resources spec")
+    );
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "0-5"));
+
+        // set cpuset.cpus via v2 unified map to 5-8 in JSON format
+        let json = serde_json::json!({"unified": {"cpuset.cpus": "5-8"}}).to_string();
+        update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "5-8"));
+
+        TestResult::Passed
+    })
+}

--- a/tests/contest/contest/src/tests/update/cpuset.rs
+++ b/tests/contest/contest/src/tests/update/cpuset.rs
@@ -37,6 +37,65 @@ fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<S
     Ok(spec)
 }
 
+// "update cgroup v2 resources via unified map"
+pub(crate) fn update_cgroup_v2_resources_via_unified_map_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_cgroup_v2_resources_via_unified_map";
+
+    let unified = HashMap::from([
+        ("cpu.max".to_string(), "500000 1000000".to_string()),
+        ("cpu.weight".to_string(), "17".to_string()),
+        ("pids.max".to_string(), "20".to_string()),
+    ]);
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .unified(unified)
+            .build()
+            .context("failed to build resources spec")
+    );
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        // Check that initial values were properly set
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.max",
+            "500000 1000000"
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.weight", "17"));
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "20"));
+
+        // set cpu.max, cpu.weight, and pids.max via v2 unified map in JSON format
+        let json = serde_json::json!({
+            "unified": {
+                "cpu.max": "max 100000",
+                "cpu.weight": "16",
+                "pids.max": "10"
+            }
+        })
+        .to_string();
+        update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "max 100000"));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.weight", "16"));
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "10"));
+
+        TestResult::Passed
+    })
+}
+
 // "update cpuset parameters via resources.CPU"
 pub(crate) fn update_cpuset_parameters_via_resources_cpu_test() -> TestResult {
     const CGROUP_NAME: &str = "update_cpuset_parameters_via_resources_cpu";

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -1,11 +1,14 @@
 mod common;
 mod cpu;
+mod cpuset;
 mod pids_limit;
 
 use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
+use libcgroups::common::{CgroupSetup, DEFAULT_CGROUP_ROOT, get_cgroup_setup};
+use libcgroups::v2::controller_type::ControllerType;
 use nix::sys::statfs::{CGROUP2_SUPER_MAGIC, statfs};
 use test_framework::{ConditionalTest, TestGroup};
 
@@ -61,6 +64,47 @@ fn can_run() -> bool {
 // TODO: remove is_runtime_runc() condition when youki supports full update CLI & support test for cgroup_v1
 fn can_run_update() -> bool {
     !is_runtime_youki() && is_cgroup_v2()
+}
+
+fn cpu_count() -> usize {
+    fs::read_to_string("/proc/cpuinfo")
+        .map(|content| {
+            content
+                .lines()
+                .filter(|line| line.starts_with("processor"))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn can_run_cpuset() -> bool {
+    let setup_result = get_cgroup_setup();
+    if !matches!(setup_result, Ok(CgroupSetup::Unified)) {
+        return false;
+    }
+
+    let controllers_result = libcgroups::v2::util::get_available_controllers(DEFAULT_CGROUP_ROOT);
+    if controllers_result.is_err() {
+        return false;
+    }
+
+    if !controllers_result
+        .unwrap()
+        .into_iter()
+        .any(|controller| controller == ControllerType::CpuSet)
+    {
+        return false;
+    }
+
+    true
+}
+
+fn can_run_cpuset_update() -> bool {
+    can_run_cpuset() && cpu_count() >= 2
+}
+
+fn can_run_cpuset_range_update() -> bool {
+    can_run_cpuset() && cpu_count() > 8
 }
 
 pub fn get_update_test() -> TestGroup {
@@ -120,6 +164,24 @@ pub fn get_update_test() -> TestGroup {
         Box::new(cpu::update_cgroup_cpu_idle_test),
     );
 
+    let update_cpuset_parameters_via_resources_cpu_test = ConditionalTest::new(
+        "update_cpuset_parameters_via_resources_cpu_test",
+        Box::new(can_run_cpuset_update),
+        Box::new(cpuset::update_cpuset_parameters_via_resources_cpu_test),
+    );
+
+    let update_cpuset_parameters_via_v2_unified_map_test = ConditionalTest::new(
+        "update_cpuset_parameters_via_v2_unified_map_test",
+        Box::new(can_run_cpuset_update),
+        Box::new(cpuset::update_cpuset_parameters_via_v2_unified_map_test),
+    );
+
+    let update_cpuset_cpus_range_via_v2_unified_map_test = ConditionalTest::new(
+        "update_cpuset_cpus_range_via_v2_unified_map_test",
+        Box::new(can_run_cpuset_range_update),
+        Box::new(cpuset::update_cpuset_cpus_range_via_v2_unified_map_test),
+    );
+
     test_group.add(vec![
         Box::new(update_cgroup_v2_common_limits_test),
         Box::new(update_pids_limit_test),
@@ -130,6 +192,9 @@ pub fn get_update_test() -> TestGroup {
         Box::new(update_cpu_period_without_previous_limits_test),
         Box::new(update_cpu_quota_without_previous_limits_test),
         Box::new(update_cgroup_cpu_idle_test),
+        Box::new(update_cpuset_parameters_via_resources_cpu_test),
+        Box::new(update_cpuset_parameters_via_v2_unified_map_test),
+        Box::new(update_cpuset_cpus_range_via_v2_unified_map_test),
     ]);
     test_group
 }

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -164,6 +164,12 @@ pub fn get_update_test() -> TestGroup {
         Box::new(cpu::update_cgroup_cpu_idle_test),
     );
 
+    let update_cgroup_v2_resources_via_unified_map_test = ConditionalTest::new(
+        "update_cgroup_v2_resources_via_unified_map_test",
+        Box::new(can_run),
+        Box::new(cpuset::update_cgroup_v2_resources_via_unified_map_test),
+    );
+
     let update_cpuset_parameters_via_resources_cpu_test = ConditionalTest::new(
         "update_cpuset_parameters_via_resources_cpu_test",
         Box::new(can_run_cpuset_update),
@@ -192,6 +198,7 @@ pub fn get_update_test() -> TestGroup {
         Box::new(update_cpu_period_without_previous_limits_test),
         Box::new(update_cpu_quota_without_previous_limits_test),
         Box::new(update_cgroup_cpu_idle_test),
+        Box::new(update_cgroup_v2_resources_via_unified_map_test),
         Box::new(update_cpuset_parameters_via_resources_cpu_test),
         Box::new(update_cpuset_parameters_via_v2_unified_map_test),
         Box::new(update_cpuset_cpus_range_via_v2_unified_map_test),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Referring to lines [L569–725 of tests/integration/update.bats](https://github.com/opencontainers/runc/blob/fc89fbd9ebec617475d7e7a7a38f4e4bf277cf54/tests/integration/update.bats#L569-L725), add a test to verify the cpuset update.

The following cases have been added:
- update cgroup v2 resources via unified map (added later)
- update cpuset parameters via resources.CPU
- update cpuset parameters via v2 unified map
- update cpuset cpus range via v2 unified map

To run the tests, the cgroup controller is detected using the same method as in the existing [cpu tests](https://github.com/youki-dev/youki/blob/04f9685b11a1486a027c2272c95ee963b9fa8c58/tests/contest/contest/src/tests/cgroups/cpu/v2.rs#L381-L4080).

- The system must have a cgroup v2 unified hierarchy
- `cpuset` must be included in `cgroup.controllers`
- For standard cpuset update tests, there must be at least two CPUs
- For CPU range update tests, there must be at least eight CPUs

The process of updating `cpuset.mems` to `1` is executed only when multiple NUMA memory nodes are available.

Additionally, in `update cgroup v2 resources via unified map` while the initial CPU settings used the cgroup v1 `cpu.shares` setting, I changed them to use `cpu.weight`, the cgroup v2 setting, from the start.
This allows the mapping from `cpu.shares` to `cpu.weight` to be removed.
https://github.com/opencontainers/runc/blob/71747fb1b2f2cad90a24b66fdc23fef154eb9861/tests/integration/helpers.bash#L367-L388

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Imprement #3576 

## Additional Context
<!-- Add any other context about the pull request here -->

Here are the results of the update tests run by `runc` and `youki`.

```
$ just validate-contest-runc update
# Start group update
1 / 13 : cpu_burst_test : ok
2 / 13 : set_cpu_period_without_quota_invalid_test : ok
3 / 13 : set_cpu_period_without_quota_test : ok
4 / 13 : set_cpu_quota_without_period_test : ok
5 / 13 : update_cgroup_cpu_idle_test : ok
6 / 13 : update_cgroup_v2_common_limits_test : ok
7 / 13 : update_cgroup_v2_resources_via_unified_map_test : ok
8 / 13 : update_cpu_period_without_previous_limits_test : ok
9 / 13 : update_cpu_quota_without_previous_limits_test : ok
10 / 13 : update_cpuset_cpus_range_via_v2_unified_map_test : skipped
        test cannot run in the current environment (run_all, parallel)
11 / 13 : update_cpuset_parameters_via_resources_cpu_test : ok
12 / 13 : update_cpuset_parameters_via_v2_unified_map_test : ok
13 / 13 : update_pids_limit_test : ok
# End group update

$ just test-contest update
# Start group update
1 / 13 : cpu_burst_test : skipped
        test cannot run in the current environment (run_all, parallel)
2 / 13 : set_cpu_period_without_quota_invalid_test : ok
3 / 13 : set_cpu_period_without_quota_test : ok
4 / 13 : set_cpu_quota_without_period_test : ok
5 / 13 : update_cgroup_cpu_idle_test : skipped
        test cannot run in the current environment (run_all, parallel)
6 / 13 : update_cgroup_v2_common_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
7 / 13 : update_cgroup_v2_resources_via_unified_map_test : ok
8 / 13 : update_cpu_period_without_previous_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
9 / 13 : update_cpu_quota_without_previous_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
10 / 13 : update_cpuset_cpus_range_via_v2_unified_map_test : skipped
        test cannot run in the current environment (run_all, parallel)
11 / 13 : update_cpuset_parameters_via_resources_cpu_test : ok
12 / 13 : update_cpuset_parameters_via_v2_unified_map_test : ok
13 / 13 : update_pids_limit_test : skipped
        test cannot run in the current environment (run_all, parallel)
# End group update
```