### PR TITLE
test(contest): add update cgroup cpu limits integration test

### DIFF
--- a/tests/contest/contest/src/tests/update/cpu.rs
+++ b/tests/contest/contest/src/tests/update/cpu.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
@@ -28,6 +29,162 @@ fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<S
     }
 
     Ok(spec)
+}
+
+// crates/libcgroups/src/v2/cpu.rs
+fn convert_shares_to_cgroup2(shares: u64) -> u64 {
+    if shares == 0 {
+        return 0;
+    }
+
+    const MIN_SHARES: u64 = 2;
+    const MAX_SHARES: u64 = 262_144;
+    const MAX_CPU_WEIGHT: u64 = 10_000;
+
+    if shares <= MIN_SHARES {
+        return 1;
+    }
+
+    if shares >= MAX_SHARES {
+        return MAX_CPU_WEIGHT;
+    }
+
+    let log_shares = (shares as f64).log2();
+    let exponent = (log_shares * log_shares + 125.0 * log_shares) / 612.0 - 7.0 / 34.0;
+    let weight = (10f64.powf(exponent)).ceil() as u64;
+
+    weight.clamp(1, MAX_CPU_WEIGHT)
+}
+
+// "update cgroup cpu limits"
+pub(crate) fn update_cpu_limits_test() -> TestResult {
+    const CGROUP_NAME: &str = "cpu_limits";
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .period(1000000_u64)
+            .quota(500000)
+            .shares(100_u64)
+            .build()
+            .context("failed to build cpu resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.max",
+            "500000 1000000"
+        ));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(100).to_string()
+        ));
+
+        // Update cpu period.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-period", "900000"],
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "500000 900000"));
+
+        // Update cpu quota.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-quota", "600000"],
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "600000 900000"));
+
+        // Remove cpu quota.
+        test_result!(update_container_and_wait(id, dir, &["--cpu-quota", "-1"],));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "max 900000"));
+
+        // Update cpu-shares.
+        test_result!(update_container_and_wait(id, dir, &["--cpu-share", "200"],));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(200).to_string()
+        ));
+
+        // Revert to the test initial value via json on stdin
+        let json = serde_json::json!({"cpu": {"shares": 100,"quota": 500000,"period": 1000000,}})
+            .to_string();
+        let update_result = update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        if !update_result.success() {
+            return TestResult::Failed(anyhow!("update cpu_limit_test via stdin failed"));
+        }
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.max",
+            "500000 1000000"
+        ));
+
+        // Redo all the changes at once.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &[
+                "--cpu-period",
+                "900000",
+                "--cpu-quota",
+                "600000",
+                "--cpu-share",
+                "200"
+            ],
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "600000 900000"));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(200).to_string()
+        ));
+
+        // Reset to initial test values via json file.
+        let json_path = dir.join("update_cpu_limits.json");
+        fs::write(&json_path, &json).unwrap();
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["-r", json_path.to_str().unwrap()]
+        ));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.max",
+            "500000 1000000"
+        ));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(100).to_string()
+        ));
+
+        TestResult::Passed
+    })
 }
 
 // "cpu burst"

--- a/tests/contest/contest/src/tests/update/cpu.rs
+++ b/tests/contest/contest/src/tests/update/cpu.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
@@ -28,6 +29,175 @@ fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<S
     }
 
     Ok(spec)
+}
+
+// Converts OCI cpu.shares to cgroup v2 cpu.weight using the same formula as
+// youki's libcgroups implementation in crates/libcgroups/src/v2/cpu.rs.
+//
+// This logic is intentionally duplicated here instead of importing it from
+// libcgroups, so the test verifies the expected conversion independently of
+// the implementation under test.
+fn convert_shares_to_cgroup2(shares: u64) -> u64 {
+    if shares == 0 {
+        return 0;
+    }
+
+    const MIN_SHARES: u64 = 2;
+    const MAX_SHARES: u64 = 262_144;
+    const MAX_CPU_WEIGHT: u64 = 10_000;
+
+    if shares <= MIN_SHARES {
+        return 1;
+    }
+
+    if shares >= MAX_SHARES {
+        return MAX_CPU_WEIGHT;
+    }
+
+    let log_shares = (shares as f64).log2();
+    let exponent = (log_shares * log_shares + 125.0 * log_shares) / 612.0 - 7.0 / 34.0;
+    let weight = (10f64.powf(exponent)).ceil() as u64;
+
+    weight.clamp(1, MAX_CPU_WEIGHT)
+}
+
+// "update cgroup cpu limits"
+pub(crate) fn update_cpu_limits_test() -> TestResult {
+    const CGROUP_NAME: &str = "cpu_limits";
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .period(1000000_u64)
+            .quota(500000)
+            .shares(100_u64)
+            .build()
+            .context("failed to build cpu resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.max",
+            "500000 1000000"
+        ));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(100).to_string()
+        ));
+
+        // Update cpu period.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-period", "900000"],
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "500000 900000"));
+
+        // Update cpu quota.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-quota", "600000"],
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "600000 900000"));
+
+        // Remove cpu quota.
+        test_result!(update_container_and_wait(id, dir, &["--cpu-quota", "-1"],));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "max 900000"));
+
+        // Update cpu-shares.
+        test_result!(update_container_and_wait(id, dir, &["--cpu-share", "200"],));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(200).to_string()
+        ));
+
+        // Revert to the test initial value via json on stdin
+        let json = serde_json::json!({"cpu": {"shares": 100,"quota": 500000,"period": 1000000,}})
+            .to_string();
+        let update_result = update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        if !update_result.success() {
+            return TestResult::Failed(anyhow!("update cpu_limit_test via stdin failed"));
+        }
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.max",
+            "500000 1000000"
+        ));
+
+        // Redo all the changes at once.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &[
+                "--cpu-period",
+                "900000",
+                "--cpu-quota",
+                "600000",
+                "--cpu-share",
+                "200"
+            ],
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "600000 900000"));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(200).to_string()
+        ));
+
+        // Remove cpu quota and reset the period.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-quota", "-1", "--cpu-period", "100000"],
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "max 100000"));
+
+        // Reset to initial test values via json file.
+        let json_path = dir.join("update_cpu_limits.json");
+        fs::write(&json_path, &json).unwrap();
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["-r", json_path.to_str().unwrap()]
+        ));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.max",
+            "500000 1000000"
+        ));
+        test_result!(check_cgroup_value(
+            &cgroup_path,
+            "cpu.weight",
+            &convert_shares_to_cgroup2(100).to_string()
+        ));
+
+        TestResult::Passed
+    })
 }
 
 // "cpu burst"

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -72,6 +72,12 @@ pub fn get_update_test() -> TestGroup {
         Box::new(common::update_common_limits_test),
     );
 
+    let update_cpu_limits_test = ConditionalTest::new(
+        "update_cpu_limits_test",
+        Box::new(can_run_update),
+        Box::new(cpu::update_cpu_limits_test),
+    );
+
     let update_pids_limit_test = ConditionalTest::new(
         "update_pids_limit_test",
         Box::new(can_run_update),
@@ -122,6 +128,7 @@ pub fn get_update_test() -> TestGroup {
 
     test_group.add(vec![
         Box::new(update_cgroup_v2_common_limits_test),
+        Box::new(update_cpu_limits_test),
         Box::new(update_pids_limit_test),
         Box::new(cpu_burst_test),
         Box::new(set_cpu_period_without_quota_test),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Port runc's "update cgroup cpu limits" test (update.bats) to contest.
Updates cpu period/quota/shares via CLI flags, stdin JSON, and a JSON file, then verifies `cpu.max` and `cpu.weight` on cgroup v2.

Skipped for youki since `youki update` does not support CPU flags yet (#147).

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
#3576 

## Additional Context
<!-- Add any other context about the pull request here -->
### youki version 0.6.0
```
$ sudo RUNTIME_KIND=youki ~/youki/scripts/contest.sh target/release/youki update
# Start group update
1 / 10 : cpu_burst_test : skipped
        test cannot run in the current environment (run_all, parallel)
2 / 10 : set_cpu_period_without_quota_invalid_test : ok
3 / 10 : set_cpu_period_without_quota_test : ok
4 / 10 : set_cpu_quota_without_period_test : ok
5 / 10 : update_cgroup_cpu_idle_test : skipped
        test cannot run in the current environment (run_all, parallel)
6 / 10 : update_cgroup_v2_common_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
7 / 10 : update_cpu_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
8 / 10 : update_cpu_period_without_previous_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
9 / 10 : update_cpu_quota_without_previous_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
10 / 10 : update_pids_limit_test : skipped
        test cannot run in the current environment (run_all, parallel)
# End group update

Validation successful for runtime ~/youki/youki
```
### runc version 1.5.0-rc.2
```
$ sudo RUNTIME_KIND="runc" ~/youki/scripts/contest.sh runc update
# Start group update
1 / 10 : cpu_burst_test : ok
2 / 10 : set_cpu_period_without_quota_invalid_test : ok
3 / 10 : set_cpu_period_without_quota_test : ok
4 / 10 : set_cpu_quota_without_period_test : ok
5 / 10 : update_cgroup_cpu_idle_test : ok
6 / 10 : update_cgroup_v2_common_limits_test : ok
7 / 10 : update_cpu_limits_test : ok
8 / 10 : update_cpu_period_without_previous_limits_test : ok
9 / 10 : update_cpu_quota_without_previous_limits_test : ok
10 / 10 : update_pids_limit_test : ok
# End group update

Validation successful for runtime runc
```