### PR TITLE
docs: fix outdated steps in WebAssembly guide

### DIFF
--- a/docs/src/user/webassembly.md
+++ b/docs/src/user/webassembly.md
@@ -2,7 +2,7 @@
 
 There are 3 things you need to do to run a WebAssembly module with youki.
 
-1. Build youki with wasm-wasmer feature flag enabled
+1. Build youki with one of the wasm feature flags enabled
 2. Build a container image with the WebAssembly module
 3. Run the container with youki
 
@@ -28,9 +28,9 @@ There are 3 things you need to do to run a WebAssembly module with youki.
 
 ## Build a container image with the WebAssembly module
 
-If you want to run a webassembly module with youki, your config.json has to include either **runc.oci.handler** or **module.wasm.image/variant=compat"**.
+If you want to run a webassembly module with youki, your config.json has to include either **run.oci.handler** or **module.wasm.image/variant=compat**.
 
-It also needs to specify a valid .wasm (webassembly binary) or .wat (webassembly test) module as entrypoint for the container. If a wat module is specified it will be compiled to a wasm module by youki before it is executed. The module also needs to be available in the root filesystem of the container obviously.
+It also needs to specify a valid .wasm (webassembly binary) or .wat (webassembly text format) module as entrypoint for the container. If a wat module is specified it will be compiled to a wasm module by youki before it is executed. The module also needs to be available in the root filesystem of the container obviously.
 
 ```json
 "ociVersion": "1.0.2-dev",
@@ -53,7 +53,7 @@ It also needs to specify a valid .wasm (webassembly binary) or .wat (webassembly
 A simple wasm module can be created by running
 
 ```console
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 cargo new wasm-module --bin
 cd ./wasm-module
 vi src/main.rs
@@ -76,7 +76,7 @@ fn main() {
 Then compile the program to WASI.
 
 ```console
-cargo build --target wasm32-wasi
+cargo build --target wasm32-wasip1
 ```
 
 ### Build a container image with the module
@@ -89,22 +89,26 @@ vi Dockerfile
 
 ```Dockerfile
 FROM scratch
-COPY target/wasm32-wasi/debug/wasm-module.wasm /
-ENTRYPOINT ["wasm-module.wasm"]
+COPY target/wasm32-wasip1/debug/wasm-module.wasm /
+ENTRYPOINT ["/wasm-module.wasm"]
 ```
 
-Then build a container image with `module.wasm.image/variant=compat` annotation. [^1]
+Then build a container image with `module.wasm.image/variant=compat` annotation.
 
 ```console
-sudo buildah build --annotation "module.wasm.image/variant=compat" -t wasm-module .
+buildah build --annotation "module.wasm.image/variant=compat" -t wasm-module .
 ```
 
 ## Run the wasm module with youki and podman
 
-Run podman with youki as runtime. [^1]
+Run podman with youki as runtime.
 
 ```bash
-sudo podman --runtime /PATH/WHARE/YOU/BUILT/WITH/WASM-WASMER/youki run localhost/wasm-module 1 2 3
+podman run --annotation "run.oci.handler=wasm" --runtime /PATH/WHERE/YOU/BUILT/youki localhost/wasm-module 1 2 3
 ```
 
-[^1]: You might need `sudo` because of [#719](https://github.com/youki-dev/youki/issues/719).
+The `--annotation "run.oci.handler=wasm"` flag tells youki to use its wasm handler. It is passed explicitly here because the `module.wasm.image/variant=compat` annotation set at build time is not always propagated to the container's `config.json` by podman.
+
+> **Note:** The command above runs rootless, which is podman's default for a non-root user, so `sudo` is not required. If your host is not set up for rootless containers (for example, missing `subuid`/`subgid` configuration) or you need functionality that requires elevated privileges, run the same command with `sudo` (rootful mode).
+>
+> Make sure `buildah` and `podman` run in the same context (both rootless, or both with `sudo`). They use separate container storage per user (`~/.local/share/containers` for rootless, `/var/lib/containers` for rootful), so building the image with one and running it with the other will fail to find `localhost/wasm-module`.

--- a/tools/wasm-sample/README.md
+++ b/tools/wasm-sample/README.md
@@ -1,7 +1,7 @@
 This is a simple wasm module for testing purposes. It prints out the arguments given to the program and all environment variables. You can compile the module with 
 
 ```
-cargo build --target wasm32-wasi
+cargo build --target wasm32-wasip1
 ```
 
 If you want youki to execute the module you must copy it to the root file system of the container and reference it in the args of the config.json. You must also ensure that the annotations contain `"run.oci.handler": "wasm"` and that youki has been compiled with one of the supported wasm runtimes. For further information please check the [documentation](https://youki-dev.github.io/youki/user/webassembly.html).


### PR DESCRIPTION
## Description
Update the WebAssembly user guide, which had several outdated or incorrect steps that prevented the walkthrough from working:

- Replace the removed `wasm32-wasi` Rust target with `wasm32-wasip1` (rustup, cargo build, and the Dockerfile COPY path)
- Use an absolute entrypoint path (`/wasm-module.wasm`) to match the sample and work across all wasm runtimes
- Pass `--annotation "run.oci.handler=wasm"` on `podman run` so the wasm handler is triggered even when the build-time annotation is not propagated
- Drop `sudo` and the stale `#719` footnote (rootless youki now uses `/run/user/{uid}/youki`), and add a note about running buildah/podman in the same rootless/rootful context
- Fix typos: `runc.oci.handler` → `run.oci.handler`, stray quote in `variant=compat"`, `WHARE` → `WHERE`
- Describe `.wat` correctly as "webassembly text format" (was "test") and generalize the feature-flag wording
- Apply the same `wasm32-wasip1` fix to `tools/wasm-sample/README.md`

## Type of Change
- [x] Documentation update

## Testing
- [x] Tested manually (please provide steps)

Verified `cargo build --target wasm32-wasip1` builds `tools/wasm-sample` successfully on Rust 1.96 (the old `wasm32-wasi` target no longer exists). Annotation keys and rootless path handling were cross-checked against the youki source (`crates/youki/src/workload/*.rs`, `crates/youki/src/rootpath.rs`).

## Related Issues
<!-- no open issue -->

## Additional Context
`wasm32-wasi` was renamed to `wasm32-wasip1` and removed from recent Rust toolchains, so the previous instructions failed at the very first step.
