### PR TITLE
fix(wasmer): enable tokio dependency for wasm-wasmer feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7328,6 +7328,7 @@ dependencies = [
  "serial_test",
  "tabwriter",
  "tempfile",
+ "tokio",
  "tracing",
  "tracing-journald",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ tar = "0.4"
 tempfile = "3"
 test_framework = { path = "tests/contest/test_framework" }
 thiserror = "2.0.18"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 tracing = "0.1.44"
 tracing-journald = "0.3.2"
 tracing-subscriber = "0.3.23"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -18,7 +18,7 @@ v1 = ["libcgroups/v1", "libcontainer/v1"]
 cgroupsv2_devices = ["libcgroups/cgroupsv2_devices", "libcontainer/cgroupsv2_devices"]
 seccomp = ["libcontainer/libseccomp"]
 
-wasm-wasmer = ["wasmer", "wasmer-wasix"]
+wasm-wasmer = ["wasmer", "wasmer-wasix", "tokio"]
 wasm-wasmedge = ["wasmedge-sdk/standalone", "wasmedge-sdk/static"]
 wasm-wasmtime = ["wasmtime", "wasi-common"]
 
@@ -37,6 +37,7 @@ serde = { workspace = true, features = ["derive"] }
 tabwriter = { workspace = true }
 clap_complete = { workspace = true }
 caps = { workspace = true }
+tokio = { workspace = true, optional = true }
 wasmer = { workspace = true, features = ["sys", "singlepass"], optional = true }
 wasmer-wasix = { workspace = true, optional = true }
 wasmedge-sdk = { workspace = true, optional = true }

--- a/crates/youki/src/workload/wasmer.rs
+++ b/crates/youki/src/workload/wasmer.rs
@@ -1,9 +1,11 @@
 use std::error::Error;
+use std::sync::Arc;
 
 use libcontainer::oci_spec::runtime::Spec;
 use libcontainer::workload::{EMPTY, Executor, ExecutorError, ExecutorValidationError};
 use wasmer::{Instance, Module, Store};
-use wasmer_wasix::{WasiEnv, WasiError};
+use wasmer_wasix::runtime::task_manager::tokio::TokioTaskManager;
+use wasmer_wasix::{PluggableRuntime, WasiEnv, WasiError};
 
 const EXECUTOR_NAME: &str = "wasmer";
 
@@ -43,6 +45,18 @@ impl Executor for WasmerExecutor {
             return Err(ExecutorError::InvalidArg);
         }
 
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|err| {
+                ExecutorError::Other(format!("could not create tokio runtime: {}", err))
+            })?;
+        let handle = rt.handle().clone();
+        let _guard = handle.enter();
+
+        let task_manager = TokioTaskManager::new(rt);
+        let runtime = PluggableRuntime::new(Arc::new(task_manager));
+
         let mut store = Store::default();
         let module = Module::from_file(&store, &args[0]).map_err(|err| {
             tracing::error!(err = ?err, file = ?args[0], "could not load wasm module from file");
@@ -52,6 +66,7 @@ impl Executor for WasmerExecutor {
         let mut wasi_env = WasiEnv::builder("youki_wasm_app")
             .args(args.iter().skip(1))
             .envs(env)
+            .runtime(Arc::new(runtime))
             .finalize(&mut store)
             .map_err(|err| ExecutorError::Other(format!("could not create wasi env: {}", err)))?;
 


### PR DESCRIPTION
## Description

Add Tokio runtime setup to the wasmer executor to fix a panic introduced by wasmer-wasix 0.700.1.

wasmer-wasix 0.700.1 requires a Tokio runtime context on the current thread for host FS and networking operations (`virtual-fs`, `virtual-net`), and an explicit `Runtime` on `WasiEnvBuilder`. The wasmer executor provided neither, causing any WASI I/O (e.g. `println!`) to panic with "there is no reactor running".

Changes:
- Add `tokio` as a workspace dependency and include it in the `wasm-wasmer` feature
- Create a Tokio multi-thread runtime and enter its context before initializing wasmer-wasix
- Pass a `PluggableRuntime` (backed by `TokioTaskManager`) to `WasiEnvBuilder` via `.runtime()`

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)

1. Built youki with `wasm-wasmer` feature: `./scripts/build.sh -o . -r -f wasm-wasmer`
2. Built `tools/wasm-sample` with `cargo build --target wasm32-wasip1`
3. Built a container image with `buildah build --annotation "module.wasm.image/variant=compat" -t wasm-module .`
4. Ran `podman run --annotation "run.oci.handler=wasm" --runtime ./youki localhost/wasm-module 1 2 3` — confirmed output without panic
5. Ran `cargo test -p youki --features wasm-wasmer` — all existing tests pass

A standalone reproduction example is available and can be added to the PR if reviewers would like to verify independently.

## Related Issues
Fixes #3672

## Additional Context
The `wasmtime` and `wasmedge` executors are not affected — this is specific to the wasmer executor. The root cause is that wasmer-wasix 0.700.1 moved host FS/networking to async Tokio-based implementations, but the executor was not updated to provide the required runtime context.
