### PR TITLE
refactor(contest): make netns setup an explicit checkpoint test step

### DIFF
--- a/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
+++ b/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
@@ -58,9 +58,11 @@ fn get_container_pid(project_path: &Path, id: &str) -> Result<i32, TestResult> {
 fn bring_up_loopback(project_path: &Path, id: &str) -> Result<(), TestResult> {
     let pid = get_container_pid(project_path, id)?;
 
-    // CRIU requires a minimal network setup in the network namespace, so this
-    // brings `lo` up. The container cannot do that itself because the default
-    // contest spec grants no NET_ADMIN, hence entering the netns from the host.
+    // Brings `lo` up so the container can talk to itself over 127.0.0.1. Only
+    // tests that actually use the loopback need this; the CRIU dump itself does
+    // not require `lo` to be up. The container cannot bring it up itself because
+    // the default contest spec grants no NET_ADMIN, hence entering the netns
+    // from the host.
     let output = match Command::new("nsenter")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -232,10 +234,6 @@ fn create_checkpoint_image_dir() -> Result<(tempfile::TempDir, std::path::PathBu
 }
 
 pub fn checkpoint_leave_running_work_path_tmp(project_path: &Path, id: &str) -> TestResult {
-    if let Err(e) = bring_up_loopback(project_path, id) {
-        return e;
-    }
-
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -251,10 +249,6 @@ pub fn checkpoint_leave_running_work_path_tmp(project_path: &Path, id: &str) -> 
 }
 
 pub fn checkpoint_leave_running(project_path: &Path, id: &str) -> TestResult {
-    if let Err(e) = bring_up_loopback(project_path, id) {
-        return e;
-    }
-
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -264,10 +258,6 @@ pub fn checkpoint_leave_running(project_path: &Path, id: &str) -> TestResult {
 }
 
 pub fn checkpoint_manage_cgroups_mode_ignore(project_path: &Path, id: &str) -> TestResult {
-    if let Err(e) = bring_up_loopback(project_path, id) {
-        return e;
-    }
-
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -310,10 +300,6 @@ pub fn checkpoint_manage_cgroups_mode_ignore(project_path: &Path, id: &str) -> T
 }
 
 pub fn checkpoint_manage_cgroups_mode_soft(project_path: &Path, id: &str) -> TestResult {
-    if let Err(e) = bring_up_loopback(project_path, id) {
-        return e;
-    }
-
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -424,11 +410,6 @@ pub fn checkpoint_link_remap() -> TestResult {
     if let Err(e) = wait_container_running(&id, bundle_path) {
         cleanup();
         return TestResult::Failed(anyhow!("container did not reach running state: {e}"));
-    }
-
-    if let Err(e) = bring_up_loopback(bundle_path, &id) {
-        cleanup();
-        return e;
     }
 
     let (_image_temp_dir, image_path) = match create_checkpoint_image_dir() {
@@ -662,10 +643,6 @@ pub fn check_external_pidns(checkpoint_dir: &Path) -> Result<(), TestResult> {
 /// Checkpoint a container started with external network and PID namespaces.
 /// Verifies that CRIU recorded both namespaces as external.
 pub fn checkpoint_with_external_namespaces(project_path: &Path, id: &str) -> TestResult {
-    if let Err(e) = bring_up_loopback(project_path, id) {
-        return e;
-    }
-
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,

--- a/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
+++ b/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
@@ -55,11 +55,13 @@ fn get_container_pid(project_path: &Path, id: &str) -> Result<i32, TestResult> {
     Ok(state.pid.unwrap_or(-1))
 }
 
-// CRIU requires a minimal network setup in the network namespace
-fn setup_network_namespace(project_path: &Path, id: &str) -> Result<(), TestResult> {
+fn bring_up_loopback(project_path: &Path, id: &str) -> Result<(), TestResult> {
     let pid = get_container_pid(project_path, id)?;
 
-    if let Err(e) = Command::new("nsenter")
+    // CRIU requires a minimal network setup in the network namespace, so this
+    // brings `lo` up. The container cannot do that itself because the default
+    // contest spec grants no NET_ADMIN, hence entering the netns from the host.
+    let output = match Command::new("nsenter")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .arg("-t")
@@ -70,9 +72,19 @@ fn setup_network_namespace(project_path: &Path, id: &str) -> Result<(), TestResu
         .expect("failed to exec ip")
         .wait_with_output()
     {
+        Ok(o) => o,
+        Err(e) => {
+            return Err(TestResult::Failed(anyhow!(
+                "error setting up network namespace {}",
+                e
+            )));
+        }
+    };
+
+    if !output.status.success() {
         return Err(TestResult::Failed(anyhow!(
-            "error setting up network namespace {}",
-            e
+            "failed to bring up loopback in network namespace: {}",
+            String::from_utf8_lossy(&output.stderr)
         )));
     }
 
@@ -97,10 +109,6 @@ fn checkpoint(
         Ok(p) => p,
         Err(e) => return e,
     };
-
-    if let Err(e) = setup_network_namespace(project_path, id) {
-        return e;
-    }
 
     let leave_running = args.contains(&"--leave-running");
 
@@ -224,6 +232,10 @@ fn create_checkpoint_image_dir() -> Result<(tempfile::TempDir, std::path::PathBu
 }
 
 pub fn checkpoint_leave_running_work_path_tmp(project_path: &Path, id: &str) -> TestResult {
+    if let Err(e) = bring_up_loopback(project_path, id) {
+        return e;
+    }
+
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -239,6 +251,10 @@ pub fn checkpoint_leave_running_work_path_tmp(project_path: &Path, id: &str) -> 
 }
 
 pub fn checkpoint_leave_running(project_path: &Path, id: &str) -> TestResult {
+    if let Err(e) = bring_up_loopback(project_path, id) {
+        return e;
+    }
+
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -248,6 +264,10 @@ pub fn checkpoint_leave_running(project_path: &Path, id: &str) -> TestResult {
 }
 
 pub fn checkpoint_manage_cgroups_mode_ignore(project_path: &Path, id: &str) -> TestResult {
+    if let Err(e) = bring_up_loopback(project_path, id) {
+        return e;
+    }
+
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -290,6 +310,10 @@ pub fn checkpoint_manage_cgroups_mode_ignore(project_path: &Path, id: &str) -> T
 }
 
 pub fn checkpoint_manage_cgroups_mode_soft(project_path: &Path, id: &str) -> TestResult {
+    if let Err(e) = bring_up_loopback(project_path, id) {
+        return e;
+    }
+
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,
@@ -402,6 +426,11 @@ pub fn checkpoint_link_remap() -> TestResult {
         return TestResult::Failed(anyhow!("container did not reach running state: {e}"));
     }
 
+    if let Err(e) = bring_up_loopback(bundle_path, &id) {
+        cleanup();
+        return e;
+    }
+
     let (_image_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => {
@@ -435,20 +464,14 @@ pub fn checkpoint_link_remap() -> TestResult {
 
 // Polls until the listen socket on `port` has a queued, unaccepted connection,
 // which is the in-flight state.
+//
+// Requires lo to be up
 fn wait_in_flight(
     project_path: &Path,
     id: &str,
     port: u16,
     timeout: std::time::Duration,
 ) -> Result<(), TestResult> {
-    // The in-flight connection only exists once lo is up. Until then the clients
-    // running inside the container cannot reach 127.0.0.1, so no connection is
-    // established and nothing accumulates in the accept queue for `ss` to report.
-    // The container itself cannot bring lo up because the default spec grants no
-    // NET_ADMIN, so we do it here from the host before polling. `checkpoint` brings
-    // it up again later, but `ip link set up` is idempotent.
-    setup_network_namespace(project_path, id)?;
-
     let pid = get_container_pid(project_path, id)?;
     let deadline = std::time::Instant::now() + timeout;
 
@@ -547,6 +570,12 @@ pub fn checkpoint_tcp_skip_in_flight() -> TestResult {
         return TestResult::Failed(anyhow!("container did not reach running state: {e}"));
     }
 
+    if let Err(e) = bring_up_loopback(bundle_path, &id) {
+        return e;
+    }
+
+    // The container only starts `tcpsvd` and `nc` once lo is up, so we have to
+    // wait for the connection to reach the accept queue before dumping.
     if let Err(e) = wait_in_flight(bundle_path, &id, PORT, std::time::Duration::from_secs(10)) {
         return e;
     }
@@ -633,6 +662,10 @@ pub fn check_external_pidns(checkpoint_dir: &Path) -> Result<(), TestResult> {
 /// Checkpoint a container started with external network and PID namespaces.
 /// Verifies that CRIU recorded both namespaces as external.
 pub fn checkpoint_with_external_namespaces(project_path: &Path, id: &str) -> TestResult {
+    if let Err(e) = bring_up_loopback(project_path, id) {
+        return e;
+    }
+
     let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
         Ok(v) => v,
         Err(e) => return e,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

setup_network_namespace was called from checkpoint(), so every checkpoint
test got the netns setup as a hidden side effect, and wait_in_flight() called it again for the tcp-skip-in-flight test. It was unclear whether checkpoint() should assume a configured netns or configure it itself.

Move the setup out of checkpoint() into prepare_checkpoint(), which each checkpoint test now calls before dumping. checkpoint() no longer touches the netns, so its precondition is explicit and the duplicated call in wait_in_flight() is gone.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes https://github.com/youki-dev/youki/issues/3658

## Additional Context
<!-- Add any other context about the pull request here -->
