### PR TITLE
feat(update): wire CPU period/quota/share into update, support negative quota

### DIFF
--- a/crates/libcgroups/src/systemd/cpu.rs
+++ b/crates/libcgroups/src/systemd/cpu.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
+use std::path::Path;
 
-use oci_spec::runtime::LinuxCpu;
+use oci_spec::runtime::{LinuxCpu, LinuxResources};
 
 use super::controller::Controller;
 use super::dbus_native::serialize::Variant;
-use crate::common::ControllerOpt;
+use crate::common::{self, ControllerOpt, WrappedIoError};
 
 pub const CPU_WEIGHT: &str = "CPUWeight";
 pub const CPU_QUOTA: &str = "CPUQuotaPerSecUSec";
@@ -15,6 +16,8 @@ const MICROSECS_PER_SEC: u64 = 1_000_000;
 pub enum SystemdCpuError {
     #[error("realtime is not supported on systemd v2 yet")]
     RealtimeSystemd,
+    #[error(transparent)]
+    Io(#[from] WrappedIoError),
 }
 
 pub(crate) struct Cpu {}
@@ -84,6 +87,46 @@ impl Cpu {
     fn is_realtime_requested(cpu: &LinuxCpu) -> bool {
         cpu.realtime_period().is_some() || cpu.realtime_runtime().is_some()
     }
+
+    // systemd re-realizes the unit on any property change, so a side the caller
+    // left out has to be carried over from the current cpu.max to survive.
+    pub(super) fn resolve_pair(
+        resources: &LinuxResources,
+        full_path: &Path,
+    ) -> Result<LinuxResources, SystemdCpuError> {
+        let mut resolved = resources.clone();
+        if let Some(cpu) = resolved.cpu_mut() {
+            if cpu.quota().is_none() || cpu.period().is_none() {
+                let (current_quota, current_period) = Self::read_current_cpu_max(full_path)?;
+                if cpu.quota().is_none() {
+                    cpu.set_quota(Some(current_quota));
+                }
+                if cpu.period().is_none() {
+                    cpu.set_period(Some(current_period));
+                }
+            }
+        }
+        Ok(resolved)
+    }
+
+    // Returns the kernel defaults when cpu.max is absent, which is the case on
+    // the first apply at container creation.
+    fn read_current_cpu_max(full_path: &Path) -> Result<(i64, u64), SystemdCpuError> {
+        let content = match common::read_cgroup_file(full_path.join("cpu.max")) {
+            Ok(content) => content,
+            Err(WrappedIoError::Read { err, .. }) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok((-1, 100_000));
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        // "max" parses as an error, which is the unlimited quota we want.
+        let mut parts = content.split_whitespace();
+        let quota = parts.next().and_then(|q| q.parse().ok()).unwrap_or(-1);
+        let period = parts.next().and_then(|p| p.parse().ok()).unwrap_or(100_000);
+
+        Ok((quota, period))
+    }
 }
 
 // Convert CPU shares (cgroup v1) into CPU weight (cgroup v2).
@@ -120,7 +163,7 @@ pub fn convert_shares_to_cgroup2(shares: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use anyhow::{Context, Result};
-    use oci_spec::runtime::LinuxCpuBuilder;
+    use oci_spec::runtime::{LinuxCpuBuilder, LinuxResourcesBuilder};
 
     use super::super::dbus_native::serialize::DbusSerialize;
     use super::*;
@@ -190,6 +233,58 @@ mod tests {
             let val = recast!(cpu_quota, Variant)?;
             assert_eq!(val, Variant::U64(period.1));
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_pair_fills_in_the_side_the_caller_left_out() -> Result<()> {
+        // (cpu.max, requested quota, requested period, expected pair)
+        let cases = [
+            (None, Some(70000i64), None, (70000i64, 100_000u64)),
+            (Some("50000 200000"), Some(70000), None, (70000, 200000)),
+            (Some("50000 200000"), None, Some(300000u64), (50000, 300000)),
+            (Some("max 100000"), None, Some(200000), (-1, 200000)),
+            (Some("50000 200000"), None, None, (50000, 200000)),
+            (None, Some(70000), Some(150000), (70000, 150000)),
+        ];
+
+        for (cpu_max, quota, period, expected) in cases {
+            let tmp = tempfile::tempdir().context("create temp dir")?;
+            if let Some(cpu_max) = cpu_max {
+                crate::test::set_fixture(tmp.path(), "cpu.max", cpu_max)
+                    .context("set cpu.max fixture")?;
+            }
+
+            let mut builder = LinuxCpuBuilder::default();
+            if let Some(quota) = quota {
+                builder = builder.quota(quota);
+            }
+            if let Some(period) = period {
+                builder = builder.period(period);
+            }
+            let resources = LinuxResourcesBuilder::default()
+                .cpu(builder.build().context("build cpu spec")?)
+                .build()
+                .context("build resources")?;
+
+            let resolved = Cpu::resolve_pair(&resources, tmp.path())?;
+            let cpu = resolved.cpu().as_ref().unwrap();
+            assert_eq!((cpu.quota().unwrap(), cpu.period().unwrap()), expected);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_pair_leaves_resources_without_cpu_untouched() -> Result<()> {
+        // the path is never read, since there is no cpu section to resolve.
+        let resources = LinuxResourcesBuilder::default()
+            .build()
+            .context("build resources")?;
+
+        let resolved = Cpu::resolve_pair(&resources, Path::new("/does/not/exist"))?;
+        assert!(resolved.cpu().is_none());
 
         Ok(())
     }

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -26,6 +26,8 @@ use crate::stats::Stats;
 use crate::systemd::dbus_native::serialize::Variant;
 use crate::systemd::io::Io;
 use crate::systemd::unified::Unified;
+use crate::v2::controller::Controller as V2Controller;
+use crate::v2::cpu::Cpu as FsCpu;
 use crate::v2::manager::{Manager as FsManager, V2ManagerError};
 
 const CONNECT_MAX_RETRIES: u32 = 7;
@@ -512,10 +514,16 @@ impl CgroupManager for Manager {
         let mut properties: HashMap<&str, Variant> = HashMap::new();
         let systemd_version = self.client.systemd_version()?;
 
+        let resolved_resources = Cpu::resolve_pair(controller_opt.resources, &self.full_path)?;
+        let cpu_controller_opt = ControllerOpt {
+            resources: &resolved_resources,
+            ..controller_opt.clone()
+        };
+
         for controller in CONTROLLER_TYPES {
             match controller {
                 ControllerType::Cpu => {
-                    Cpu::apply(controller_opt, systemd_version, &mut properties)?;
+                    Cpu::apply(&cpu_controller_opt, systemd_version, &mut properties)?;
                 }
 
                 ControllerType::CpuSet => {
@@ -543,6 +551,11 @@ impl CgroupManager for Manager {
             self.client
                 .set_unit_properties(&self.unit_name, &properties)?;
         }
+
+        // systemd has no properties for cpu burst and idle, and it resets the
+        // period to its default whenever the quota is unset.
+        <FsCpu as V2Controller>::apply(&cpu_controller_opt, &self.full_path)
+            .map_err(|err| SystemdManagerError::V2Manager(err.into()))?;
 
         Ok(())
     }

--- a/crates/libcgroups/src/v2/controller.rs
+++ b/crates/libcgroups/src/v2/controller.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::common::ControllerOpt;
 
-pub(super) trait Controller {
+pub(crate) trait Controller {
     type Error;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_path: &Path) -> Result<(), Self::Error>;

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -97,8 +97,14 @@ impl Cpu {
         if let Some(mut shares) = cpu.shares() {
             shares = Self::convert_shares_to_cgroup2(shares);
             if shares != 0 {
-                // will result in Erno 34 (numerical result out of range) otherwise
-                common::write_cgroup_file(path.join(CGROUP_CPU_WEIGHT), shares)?;
+                // The kernel pins cpu.weight to 0 on an idle cgroup and rejects
+                // any other value, so a weight asked for alongside idle gives way.
+                if cpu.idle() == Some(1) {
+                    tracing::warn!(shares, "ignoring cpu shares because the cgroup is idle");
+                } else {
+                    // will result in Erno 34 (numerical result out of range) otherwise
+                    common::write_cgroup_file(path.join(CGROUP_CPU_WEIGHT), shares)?;
+                }
             }
         }
 

--- a/crates/libcgroups/src/v2/mod.rs
+++ b/crates/libcgroups/src/v2/mod.rs
@@ -1,6 +1,6 @@
-mod controller;
+pub(crate) mod controller;
 pub mod controller_type;
-mod cpu;
+pub(crate) mod cpu;
 mod cpuset;
 #[cfg(feature = "cgroupsv2_devices")]
 pub mod devices;

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -34,6 +34,14 @@ pub struct Update {
     #[arg(long)]
     pub cpu_share: Option<u64>,
 
+    /// Set CPU burst limit within a given period (in microseconds)
+    #[arg(long)]
+    pub cpu_burst: Option<u64>,
+
+    /// Set cgroup SCHED_IDLE or not. 0: default behavior, 1: SCHED_IDLE.
+    #[arg(long)]
+    pub cpu_idle: Option<i64>,
+
     /// Set CPU(s) to use. The list can contain commas and ranges. For example: 0-3,7
     #[arg(long)]
     pub cpuset_cpus: Option<String>,

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -19,8 +19,8 @@ pub struct Update {
     pub cpu_period: Option<u64>,
 
     /// Set CPU usage limit within a given period (in microseconds)
-    #[arg(long)]
-    pub cpu_quota: Option<u64>,
+    #[arg(long, allow_hyphen_values = true)]
+    pub cpu_quota: Option<i64>,
 
     /// Set CPU realtime period to be used for hardcapping (in microseconds)
     #[arg(long)]

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -18,7 +18,8 @@ pub struct Update {
     #[arg(long)]
     pub cpu_period: Option<u64>,
 
-    /// Set CPU usage limit within a given period (in microseconds)
+    /// Set CPU usage limit within a given period (in microseconds).
+    /// Use a negative value to unset the quota.
     #[arg(long, allow_hyphen_values = true)]
     pub cpu_quota: Option<i64>,
 

--- a/crates/youki/src/commands/update.rs
+++ b/crates/youki/src/commands/update.rs
@@ -4,7 +4,9 @@ use std::{fs, io};
 use anyhow::Result;
 use libcgroups::common::{CgroupManager, ControllerOpt};
 use libcgroups::{self};
-use libcontainer::oci_spec::runtime::{LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder};
+use libcontainer::oci_spec::runtime::{
+    LinuxCpu, LinuxCpuBuilder, LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder,
+};
 use liboci_cli::Update;
 
 use crate::commands::create_cgroup_manager;
@@ -26,6 +28,9 @@ pub fn update(args: Update, root_path: PathBuf) -> Result<()> {
         if let Some(new_pids_limit) = args.pids_limit {
             builder = builder.pids(LinuxPidsBuilder::default().limit(new_pids_limit).build()?);
         }
+        if let Some(cpu) = build_cpu(&args)? {
+            builder = builder.cpu(cpu);
+        }
         linux_res = builder.build()?;
     }
 
@@ -36,4 +41,85 @@ pub fn update(args: Update, root_path: PathBuf) -> Result<()> {
         freezer_state: None,
     })?;
     Ok(())
+}
+
+fn build_cpu(args: &Update) -> Result<Option<LinuxCpu>> {
+    let mut builder = LinuxCpuBuilder::default();
+    if let Some(v) = args.cpu_period {
+        builder = builder.period(v);
+    }
+    if let Some(v) = args.cpu_quota {
+        builder = builder.quota(v);
+    }
+    if let Some(v) = args.cpu_share {
+        builder = builder.shares(v);
+    }
+
+    let cpu = builder.build()?;
+    let empty = LinuxCpuBuilder::default()
+        .build()
+        .expect("building an empty LinuxCpu can't fail");
+    Ok((cpu != empty).then_some(cpu))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_args() -> Update {
+        Update {
+            resources: None,
+            blkio_weight: None,
+            cpu_period: None,
+            cpu_quota: None,
+            cpu_rt_period: None,
+            cpu_rt_runtime: None,
+            cpu_share: None,
+            cpuset_cpus: None,
+            cpuset_mems: None,
+            memory: None,
+            memory_reservation: None,
+            memory_swap: None,
+            pids_limit: None,
+            l3_cache_schema: None,
+            mem_bw_schema: None,
+            container_id: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_build_cpu_none_when_no_flags() {
+        let args = base_args();
+        assert!(build_cpu(&args).unwrap().is_none());
+    }
+
+    #[test]
+    fn build_cpu_sets_period() {
+        let args = Update {
+            cpu_period: Some(900000),
+            ..base_args()
+        };
+        let cpu = build_cpu(&args).unwrap().unwrap();
+        assert_eq!(cpu.period(), Some(900000));
+    }
+
+    #[test]
+    fn build_cpu_sets_quota() {
+        let args = Update {
+            cpu_quota: Some(500000),
+            ..base_args()
+        };
+        let cpu = build_cpu(&args).unwrap().unwrap();
+        assert_eq!(cpu.quota(), Some(500000));
+    }
+
+    #[test]
+    fn build_cpu_sets_share() {
+        let args = Update {
+            cpu_share: Some(100),
+            ..base_args()
+        };
+        let cpu = build_cpu(&args).unwrap().unwrap();
+        assert_eq!(cpu.shares(), Some(100));
+    }
 }

--- a/crates/youki/src/commands/update.rs
+++ b/crates/youki/src/commands/update.rs
@@ -54,6 +54,15 @@ fn build_cpu(args: &Update) -> Result<Option<LinuxCpu>> {
     if let Some(v) = args.cpu_share {
         builder = builder.shares(v);
     }
+    if let Some(v) = args.cpu_burst {
+        builder = builder.burst(v);
+    }
+    if let Some(v) = args.cpu_idle {
+        if v != 0 && v != 1 {
+            anyhow::bail!("invalid value for --cpu-idle: {v} (expected 0 or 1)");
+        }
+        builder = builder.idle(v);
+    }
 
     let cpu = builder.build()?;
     let empty = LinuxCpuBuilder::default()
@@ -75,6 +84,8 @@ mod tests {
             cpu_rt_period: None,
             cpu_rt_runtime: None,
             cpu_share: None,
+            cpu_burst: None,
+            cpu_idle: None,
             cpuset_cpus: None,
             cpuset_mems: None,
             memory: None,
@@ -121,5 +132,36 @@ mod tests {
         };
         let cpu = build_cpu(&args).unwrap().unwrap();
         assert_eq!(cpu.shares(), Some(100));
+    }
+
+    #[test]
+    fn build_cpu_sets_burst() {
+        let args = Update {
+            cpu_burst: Some(500000),
+            ..base_args()
+        };
+        let cpu = build_cpu(&args).unwrap().unwrap();
+        assert_eq!(cpu.burst(), Some(500000));
+    }
+
+    #[test]
+    fn build_cpu_sets_idle() {
+        for idle in [0, 1] {
+            let args = Update {
+                cpu_idle: Some(idle),
+                ..base_args()
+            };
+            let cpu = build_cpu(&args).unwrap().unwrap();
+            assert_eq!(cpu.idle(), Some(idle));
+        }
+    }
+
+    #[test]
+    fn build_cpu_rejects_invalid_idle() {
+        let args = Update {
+            cpu_idle: Some(2),
+            ..base_args()
+        };
+        assert!(build_cpu(&args).is_err());
     }
 }

--- a/crates/youki/src/commands/update.rs
+++ b/crates/youki/src/commands/update.rs
@@ -58,6 +58,8 @@ fn build_cpu(args: &Update) -> Result<Option<LinuxCpu>> {
         builder = builder.burst(v);
     }
     if let Some(v) = args.cpu_idle {
+        // idle only has meaning as 0/1; reject other values here rather
+        // than rely on kernel EINVAL.
         if v != 0 && v != 1 {
             anyhow::bail!("invalid value for --cpu-idle: {v} (expected 0 or 1)");
         }
@@ -65,10 +67,7 @@ fn build_cpu(args: &Update) -> Result<Option<LinuxCpu>> {
     }
 
     let cpu = builder.build()?;
-    let empty = LinuxCpuBuilder::default()
-        .build()
-        .expect("building an empty LinuxCpu can't fail");
-    Ok((cpu != empty).then_some(cpu))
+    Ok((cpu != LinuxCpu::default()).then_some(cpu))
 }
 
 #[cfg(test)]
@@ -99,69 +98,49 @@ mod tests {
     }
 
     #[test]
-    fn test_build_cpu_none_when_no_flags() {
+    fn none_when_no_flags() {
         let args = base_args();
         assert!(build_cpu(&args).unwrap().is_none());
     }
 
     #[test]
-    fn build_cpu_sets_period() {
-        let args = Update {
-            cpu_period: Some(900000),
-            ..base_args()
-        };
-        let cpu = build_cpu(&args).unwrap().unwrap();
-        assert_eq!(cpu.period(), Some(900000));
-    }
-
-    #[test]
-    fn build_cpu_sets_quota() {
-        let args = Update {
-            cpu_quota: Some(500000),
-            ..base_args()
-        };
-        let cpu = build_cpu(&args).unwrap().unwrap();
-        assert_eq!(cpu.quota(), Some(500000));
-    }
-
-    #[test]
-    fn build_cpu_sets_share() {
-        let args = Update {
-            cpu_share: Some(100),
-            ..base_args()
-        };
-        let cpu = build_cpu(&args).unwrap().unwrap();
-        assert_eq!(cpu.shares(), Some(100));
-    }
-
-    #[test]
-    fn build_cpu_sets_burst() {
-        let args = Update {
-            cpu_burst: Some(500000),
-            ..base_args()
-        };
-        let cpu = build_cpu(&args).unwrap().unwrap();
-        assert_eq!(cpu.burst(), Some(500000));
-    }
-
-    #[test]
-    fn build_cpu_sets_idle() {
+    fn build_cpu_sets_all_fields() {
         for idle in [0, 1] {
             let args = Update {
+                cpu_period: Some(900000),
+                cpu_quota: Some(500000),
+                cpu_share: Some(100),
+                cpu_burst: Some(500000),
                 cpu_idle: Some(idle),
                 ..base_args()
             };
             let cpu = build_cpu(&args).unwrap().unwrap();
+            assert_eq!(cpu.period(), Some(900000));
+            assert_eq!(cpu.quota(), Some(500000));
+            assert_eq!(cpu.shares(), Some(100));
+            assert_eq!(cpu.burst(), Some(500000));
             assert_eq!(cpu.idle(), Some(idle));
         }
     }
 
     #[test]
-    fn build_cpu_rejects_invalid_idle() {
+    fn build_cpu_sets_negative_quota() {
         let args = Update {
-            cpu_idle: Some(2),
+            cpu_quota: Some(-1),
             ..base_args()
         };
-        assert!(build_cpu(&args).is_err());
+        let cpu = build_cpu(&args).unwrap().unwrap();
+        assert_eq!(cpu.quota(), Some(-1));
+    }
+
+    #[test]
+    fn build_cpu_rejects_invalid_idle() {
+        for idle in [-1, 2, 3] {
+            let args = Update {
+                cpu_idle: Some(idle),
+                ..base_args()
+            };
+            assert!(build_cpu(&args).is_err());
+        }
     }
 }

--- a/tests/contest/contest/src/tests/update/cpu.rs
+++ b/tests/contest/contest/src/tests/update/cpu.rs
@@ -58,7 +58,12 @@ pub(crate) fn cpu_burst_test() -> TestResult {
         test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "500000"));
 
         // Ensure a memory-only update does not reset cpu.max.burst.
-        test_result!(update_container_and_wait(id, dir, &["--memory", "100M"]));
+        // 100MiB in bytes: youki's --memory has no unit-suffix parsing yet.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--memory", "104857600"]
+        ));
         test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "500000"));
 
         test_result!(update_container_and_wait(

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -80,7 +80,7 @@ pub fn get_update_test() -> TestGroup {
 
     let cpu_burst_test = ConditionalTest::new(
         "cpu_burst_test",
-        Box::new(can_run_update),
+        Box::new(can_run),
         Box::new(cpu::cpu_burst_test),
     );
 
@@ -104,19 +104,19 @@ pub fn get_update_test() -> TestGroup {
 
     let update_cpu_period_without_previous_limits_test = ConditionalTest::new(
         "update_cpu_period_without_previous_limits_test",
-        Box::new(can_run_update),
+        Box::new(can_run),
         Box::new(cpu::update_cpu_period_without_previous_limits_test),
     );
 
     let update_cpu_quota_without_previous_limits_test = ConditionalTest::new(
         "update_cpu_quota_without_previous_limits_test",
-        Box::new(can_run_update),
+        Box::new(can_run),
         Box::new(cpu::update_cpu_quota_without_previous_limits_test),
     );
 
     let update_cgroup_cpu_idle_test = ConditionalTest::new(
         "update_cgroup_cpu_idle_test",
-        Box::new(can_run_update),
+        Box::new(can_run),
         Box::new(cpu::update_cgroup_cpu_idle_test),
     );
 


### PR DESCRIPTION
## Description
- Wire `--cpu-period` / `--cpu-quota` / `--cpu-share` in `youki update` into the actual cgroup update
- Accept negative values (e.g. `-1`) for `--cpu-quota` to remove the quota limit, matching runc's behavior
- Wire `--cpu-burst` / `--cpu-idle` into the update as well, rejecting `--cpu-idle` values other than 0/1
- Unskip the update CPU contest tests now covered by youki (`cpu_burst_test`, `update_cgroup_cpu_idle_test`, `update_cpu_period_without_previous_limits_test`, `update_cpu_quota_without_previous_limits_test`)
- Fix `cpu_burst_test`'s `--memory 100M` step to use a raw byte count (`104857600`), since youki's `--memory` doesn't support unit-suffix parsing yet (unlike runc's `RAMInBytes`); this only surfaced once the test started running against youki

Part of #3676

@utam0k @saku3 `cpu_burst_test` ports runc's test verbatim, but its `--memory 100M` step needed changing to a raw byte count since youki's `--memory` has no unit-suffix parsing yet. Is that an acceptable stopgap, or should this test stay runc-only until `--memory` supports suffixes?


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)


## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3676 

## Additional Context
<!-- Add any other context about the pull request here --> 
unui tests check (youki version: 0.7.0)
```
running 4 tests
test commands::update::tests::build_cpu_sets_negative_quota ... ok
test commands::update::tests::build_cpu_sets_all_fields ... ok
test commands::update::tests::build_cpu_rejects_invalid_idle ... ok
test commands::update::tests::none_when_no_flags ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 18 filtered out; finished in 0.00s
```
contest check (youki version: 0.7.0)
```
$ just test-contest update
# Start group update
1 / 9 : cpu_burst_test : ok
2 / 9 : set_cpu_period_without_quota_invalid_test : ok
3 / 9 : set_cpu_period_without_quota_test : ok
4 / 9 : set_cpu_quota_without_period_test : ok
5 / 9 : update_cgroup_cpu_idle_test : ok
6 / 9 : update_cgroup_v2_common_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
7 / 9 : update_cpu_period_without_previous_limits_test : ok
8 / 9 : update_cpu_quota_without_previous_limits_test : ok
9 / 9 : update_pids_limit_test : skipped
        test cannot run in the current environment (run_all, parallel)
# End group update

Validation successful for runtime /home/kohei/work/youki/youki
```
