### PR TITLE
fix(libcontainer): postpone cgroup limits application to main process

### DIFF
--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -55,7 +55,7 @@ pub struct Update {
     pub memory_swap: Option<i64>,
 
     /// Set the maximum number of processes allowed in the container
-    #[arg(long)]
+    #[arg(long, allow_hyphen_values = true)]
     pub pids_limit: Option<i64>,
 
     /// Set the value for Intel RDT/CAT L3 cache schema.


### PR DESCRIPTION
Description
Problem
When pids.limit is set to 1 in config.json, container creation fails with a fork/clone error:

ERROR libcontainer::process::container_intermediate_process: failed to fork init process: failed to clone process
This happens because the container_intermediate_process applies the cgroup resource limits (cgroup_manager.apply()) before cloning the init process. Since the intermediate process is already inside the target cgroup, the limit of 1 is enforced immediately. When it attempts to clone the init process, the clone syscall fails because it would temporarily bring the process count in the cgroup to 2, which exceeds the limit of 1.

Solution
To align with runc behavior and allow successful container creation with a pids.limit of 1, we postpone the application of cgroup resource limits:

The intermediate process still joins the cgroup (cmanager.add_task(pid)) before entering namespaces and cloning, ensuring the init process is created inside the correct cgroup. However, it no longer calls .apply().
Once the main process receives the init_pid from the intermediate process (confirming the init process was cloned successfully), the main process instantiates the cgroup manager and calls .apply(...) to write the resource limits.
Linux cgroups allow writing a limit (like pids.max = 1) that is lower than the current count of tasks (which is temporarily 2: intermediate process + init process). The kernel accepts the write without error, and once the intermediate process exits shortly after, the task count drops to 1, correctly enforcing the limit.
Changes
crates/libcontainer/src/process/container_intermediate_process.rs:
Simplified apply_cgroups to only add the task to the cgroup. Removed resources and init parameters.
Cleaned up the unused import of LinuxResources.
Updated and simplified unit tests in the module.
crates/libcontainer/src/process/container_main_process.rs:
Added the Cgroup(String) variant to ProcessError.
Implemented cgroup resource limits application in container_main_process after receiving init_pid for InitContainer.
Testing
Verified the fix with pids.limit = 1.
Ran the libcontainer test suite: 264 tests passed.
Two TTY-related tests fail in the WSL environment because /dev/ptmx is not backed by a real devpts mount; the same failures occur independently of this change.
Related Issues
Closes #3644 
Refs #3594