### PR TITLE
specify systemd as Podman's cgroup manager for rootless-podman-test

### DIFF
--- a/tests/rootless-tests/run.sh
+++ b/tests/rootless-tests/run.sh
@@ -5,6 +5,10 @@ set -ex
 
 runtime=$1
 
+# log the podman version and cgroup manager
+podman --version
+podman info --format '{{.Host.CgroupManager}}'
+
 podman rm --force --ignore create-test # remove if existing
 
 podman create --runtime $runtime --name create-test hello-world
@@ -19,7 +23,9 @@ echo $log | grep $rand
 
 podman kill exec-test || true # ignore failure for killing
 podman rm --force --ignore exec-test
-podman run -d --runtime $runtime --name exec-test busybox sleep 10m
+# TODO: In rootless mode with the `cgroupfs` cgroup manager, youki behaves differently from runc, so explicitly use `systemd`.
+# See: https://github.com/youki-dev/youki/issues/3690
+podman --cgroup-manager systemd run -d --runtime $runtime --name exec-test busybox sleep 10m
 
 rand=$(head -c 10 /dev/random | base64)
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This is a temporary workaround for the following issue.

https://github.com/youki-dev/youki/issues/3690

Following a recent update to the GitHub Actions ubuntu-24.04 runner image, Podman started using cgroupfs as its cgroup manager.

This PR explicitly passes --cgroup-manager systemd when running Podman.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
