### PR TITLE
harden unified cgroup config

### DIFF
--- a/crates/libcgroups/src/systemd/unified.rs
+++ b/crates/libcgroups/src/systemd/unified.rs
@@ -30,6 +30,10 @@ pub enum SystemdUnifiedError {
     },
     #[error("failed to to parse pids.max {value}: {err}")]
     PidsMax { err: ParseIntError, value: String },
+    #[error("unified resource {filename} must be a file name (no slashes)")]
+    InvalidFilename { filename: String },
+    #[error("unified resource {filename} must be in the form CONTROLLER.PARAMETER")]
+    InvalidFormat { filename: String },
 }
 
 pub struct Unified {}
@@ -58,6 +62,16 @@ impl Unified {
         properties: &mut HashMap<&str, Variant>,
     ) -> Result<(), SystemdUnifiedError> {
         for (key, value) in unified {
+            if key.contains('/') {
+                return Err(SystemdUnifiedError::InvalidFilename {
+                    filename: key.into(),
+                });
+            }
+            if !key.contains('.') || key.starts_with('.') {
+                return Err(SystemdUnifiedError::InvalidFormat {
+                    filename: key.into(),
+                });
+            }
             match key.as_str() {
                 "cpu.weight" => {
                     let shares =
@@ -248,5 +262,62 @@ mod tests {
         assert_eq!(recast!(cpu_quota, Variant)?, Variant::U64(500000));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_key_with_slash_returns_error() {
+        let unified: HashMap<String, String> = [("/memory/max", "100000")]
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+        let mut actual: HashMap<&str, Variant> = HashMap::new();
+
+        let result = Unified::apply(&unified, 245, &mut actual);
+
+        assert!(matches!(
+            result,
+            Err(SystemdUnifiedError::InvalidFilename { .. })
+        ));
+        assert!(actual.is_empty());
+    }
+
+    #[test]
+    fn test_key_without_dot_returns_error() {
+        // arrange
+        let unified: HashMap<String, String> = [("foo", "100000")]
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+        let mut actual: HashMap<&str, Variant> = HashMap::new();
+
+        // act
+        let result = Unified::apply(&unified, 245, &mut actual);
+
+        // assert
+        assert!(matches!(
+            result,
+            Err(SystemdUnifiedError::InvalidFormat { .. })
+        ));
+        assert!(actual.is_empty());
+    }
+
+    #[test]
+    fn test_key_starting_with_dot_returns_error() {
+        // arrange
+        let unified: HashMap<String, String> = [(".max", "100000")]
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+        let mut actual: HashMap<&str, Variant> = HashMap::new();
+
+        // act
+        let result = Unified::apply(&unified, 245, &mut actual);
+
+        // assert
+        assert!(matches!(
+            result,
+            Err(SystemdUnifiedError::InvalidFormat { .. })
+        ));
+        assert!(actual.is_empty());
     }
 }

--- a/crates/libcgroups/src/v2/unified.rs
+++ b/crates/libcgroups/src/v2/unified.rs
@@ -13,6 +13,10 @@ pub enum V2UnifiedError {
         subsystem: String,
         err: WrappedIoError,
     },
+    #[error("unified resource {filename} must be a file name (no slashes)")]
+    InvalidFilename { filename: String },
+    #[error("unified resource {filename} must be in the form CONTROLLER.PARAMETER")]
+    InvalidFormat { filename: String },
 }
 
 pub struct Unified {}
@@ -37,6 +41,16 @@ impl Unified {
     ) -> Result<(), V2UnifiedError> {
         tracing::debug!("Apply unified cgroup config");
         for (cgroup_file, value) in unified {
+            if cgroup_file.contains('/') {
+                return Err(V2UnifiedError::InvalidFilename {
+                    filename: cgroup_file.into(),
+                });
+            }
+            if !cgroup_file.contains('.') || cgroup_file.starts_with('.') {
+                return Err(V2UnifiedError::InvalidFormat {
+                    filename: cgroup_file.into(),
+                });
+            }
             if let Err(err) = common::write_cgroup_file_str(cgroup_path.join(cgroup_file), value) {
                 let (subsystem, _) = cgroup_file.split_once('.').unwrap_or((cgroup_file, ""));
 
@@ -175,5 +189,98 @@ mod tests {
 
         // assert
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_unified_slash_in_key() {
+        // arrange
+        let tmp = tempfile::tempdir().unwrap();
+
+        let unified = {
+            let mut u = HashMap::new();
+            u.insert("/memory/max".to_owned(), "100000".to_owned());
+            u
+        };
+
+        let resources = LinuxResourcesBuilder::default()
+            .unified(unified)
+            .build()
+            .unwrap();
+
+        let controller_opt = ControllerOpt {
+            resources: &resources,
+            freezer_state: None,
+            oom_score_adj: None,
+            disable_oom_killer: false,
+        };
+
+        // act
+        let result = Unified::apply(&controller_opt, tmp.path(), vec![]);
+
+        // assert
+        assert!(matches!(
+            result,
+            Err(V2UnifiedError::InvalidFilename { .. })
+        ));
+    }
+
+    #[test]
+    fn test_set_unified_key_without_dot() {
+        // arrange
+        let tmp = tempfile::tempdir().unwrap();
+
+        let unified = {
+            let mut u = HashMap::new();
+            u.insert("cpumax".to_owned(), "100000".to_owned());
+            u
+        };
+
+        let resources = LinuxResourcesBuilder::default()
+            .unified(unified)
+            .build()
+            .unwrap();
+
+        let controller_opt = ControllerOpt {
+            resources: &resources,
+            freezer_state: None,
+            oom_score_adj: None,
+            disable_oom_killer: false,
+        };
+
+        // act
+        let result = Unified::apply(&controller_opt, tmp.path(), vec![]);
+
+        // assert
+        assert!(matches!(result, Err(V2UnifiedError::InvalidFormat { .. })));
+    }
+
+    #[test]
+    fn test_set_unified_key_starting_with_dot() {
+        // arrange
+        let tmp = tempfile::tempdir().unwrap();
+
+        let unified = {
+            let mut u = HashMap::new();
+            u.insert(".max".to_owned(), "100000".to_owned());
+            u
+        };
+
+        let resources = LinuxResourcesBuilder::default()
+            .unified(unified)
+            .build()
+            .unwrap();
+
+        let controller_opt = ControllerOpt {
+            resources: &resources,
+            freezer_state: None,
+            oom_score_adj: None,
+            disable_oom_killer: false,
+        };
+
+        // act
+        let result = Unified::apply(&controller_opt, tmp.path(), vec![]);
+
+        // assert
+        assert!(matches!(result, Err(V2UnifiedError::InvalidFormat { .. })));
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This improves compatibility with runc for cgroup unified settings.

`linux.resources.unified` allows cgroup parameters to be specified as key-value pairs and written to the corresponding cgroup files. This change adds validation for the keys to match runc's behavior.

* cgroup v2
  * https://github.com/opencontainers/cgroups/blob/974f3a5079fe3cc9b8f4ff519233b9ccf7072f9f/fs2/fs2.go#L281
* systemd 
  * https://github.com/opencontainers/cgroups/blob/974f3a5079fe3cc9b8f4ff519233b9ccf7072f9f/systemd/v2.go#L76 

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
