### PR TITLE
refactor(contest): extract run_container_with_console helper into test_utils

### DIFF
--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -8,7 +8,7 @@ use std::os::unix::fs::symlink;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow, bail};
@@ -19,8 +19,8 @@ use test_framework::{ConditionalTest, TestGroup, TestResult};
 use crate::utils::{
     LifecycleStatus, WaitTarget, build_checkpoint_command, checkpoint_container, criu_has_feature,
     criu_installed, delete_container, exec_container, generate_uuid, get_container_pid,
-    get_runtime_path, handle_console_socket, is_runtime_youki, kill_container, net, prepare_bundle,
-    restore_container, set_config, try_checkpoint_container, wait_container_running,
+    get_runtime_path, is_runtime_youki, kill_container, net, prepare_bundle, restore_container,
+    run_container_with_console, set_config, try_checkpoint_container, wait_container_running,
     wait_for_state,
 };
 
@@ -75,38 +75,9 @@ impl CrTestContext {
         self.restore_id = Some(rid);
     }
 
-    // TODO: Consider extracting this into test_utils.rs as run_container_with_console (see issue #3529)
     fn start(&self) -> Result<(), TestResult> {
-        let runtime_path = get_runtime_path();
-        let actual_bundle_path = self.bundle.path().join("bundle");
-        let console_socket = self.bundle.path().join("console.sock");
-        let listener = std::os::unix::net::UnixListener::bind(&console_socket)
-            .map_err(|e| TestResult::Failed(anyhow!("failed to bind console socket: {e}")))?;
-
         let run_result = (|| -> Result<()> {
-            let mut child = std::process::Command::new(runtime_path)
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .arg("--root")
-                .arg(self.bundle.path().join("runtime"))
-                .arg("run")
-                .arg("-d")
-                .arg("--bundle")
-                .arg(&actual_bundle_path)
-                .arg("--console-socket")
-                .arg(&console_socket)
-                .arg(&self.id)
-                .current_dir(self.bundle.path())
-                .spawn()?;
-
-            let (stream, _) = listener.accept()?;
-            handle_console_socket(stream);
-
-            let status = child.wait()?;
-            if !status.success() {
-                bail!("run -d failed ({status})");
-            }
+            run_container_with_console(get_runtime_path(), self.bundle.path(), &self.id)?;
 
             wait_container_running(&self.id, &self.bundle)?;
             ping_container(self.bundle.path())

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -9,8 +9,8 @@ pub use support::{
 pub use test_utils::{
     CreateOptions, LifecycleStatus, State, WaitTarget, build_checkpoint_command,
     checkpoint_container, create_container, criu_has_feature, criu_installed, delete_container,
-    exec_container, get_container_pid, get_state, handle_console_socket, kill_container,
-    kill_container_with_signal, restore_container, start_container, test_inside_container,
+    exec_container, get_container_pid, get_state, kill_container, kill_container_with_signal,
+    restore_container, run_container_with_console, start_container, test_inside_container,
     test_outside_container, try_checkpoint_container, update_container,
     update_container_with_stdin, wait_container_running, wait_for_state,
 };

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -570,6 +570,53 @@ pub fn handle_console_socket(stream: std::os::unix::net::UnixStream) {
     });
 }
 
+/// Runs a container in detached mode with an OCI terminal (`run -d --console-socket`).
+///
+/// Binds a console socket next to the bundle, spawns the runtime in detached mode,
+/// accepts the console socket connection and hands it off to [`handle_console_socket`].
+/// Returns an error if the runtime process exits with a non-zero status.
+pub fn run_container_with_console(
+    runtime_path: &Path,
+    bundle_path: &Path,
+    container_id: &str,
+) -> Result<()> {
+    let console_socket = bundle_path.join("console.sock");
+    if console_socket.exists() {
+        std::fs::remove_file(&console_socket)
+            .context("failed to remove existing console socket")?;
+    }
+    let listener = std::os::unix::net::UnixListener::bind(&console_socket)
+        .context("failed to bind console socket")?;
+
+    let mut child = Command::new(runtime_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .arg("--root")
+        .arg(bundle_path.join("runtime"))
+        .arg("run")
+        .arg("-d")
+        .arg("--bundle")
+        .arg(bundle_path.join("bundle"))
+        .arg("--console-socket")
+        .arg(&console_socket)
+        .arg(container_id)
+        .current_dir(bundle_path)
+        .spawn()
+        .context("failed to spawn run -d")?;
+
+    let (stream, _) = listener
+        .accept()
+        .context("failed to accept console socket")?;
+    handle_console_socket(stream);
+
+    let status = child.wait().context("failed to wait for run -d")?;
+    if !status.success() {
+        bail!("run -d failed ({status})");
+    }
+    Ok(())
+}
+
 /// Checkpoint a running container into `image_dir`.
 ///
 /// * `global_args` are passed before the `checkpoint` subcommand (e.g., `&["--debug"]`).


### PR DESCRIPTION
Closes #3529

Extracts the detached-run + console-socket handling (`run -d --console-socket`) out of `CrTestContext::start` into a reusable global helper `run_container_with_console` in `tests/contest/contest/src/utils/test_utils.rs`, as agreed in the review of #3493.

- New `pub fn run_container_with_console(runtime_path, bundle_path, container_id)` in `utils/test_utils.rs`
- `CrTestContext::start` now delegates to it (removes the TODO referencing #3529)
- Re-exported via `utils/mod.rs`; `handle_console_socket` re-export dropped (fn stays pub in `test_utils`)
- Also removes a stale `console.sock` before binding, mirroring the restore path

Validation:
- `cargo check -p contest --all-targets` ✅
- `cargo clippy -p contest --all-targets --all-features -- -D warnings` ✅
- `cargo fmt -p contest -- --check` ✅

Note: local `cargo test --no-run` link needs `libseccomp` (missing in this WSL env); code compiles clean and CI runners have it.

cc maintainers — no rush.