### PR TITLE
test: port OCI state validation

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -56,6 +56,7 @@ use crate::tests::rootfs_propagation::get_rootfs_propagation_test;
 use crate::tests::scheduler::get_scheduler_test;
 use crate::tests::seccomp::get_seccomp_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
+use crate::tests::state::get_state_test;
 use crate::tests::sysctl::get_sysctl_test;
 use crate::tests::time_ns::get_time_ns_test;
 use crate::tests::tlb::get_tlb_test;
@@ -148,6 +149,7 @@ fn main() -> Result<()> {
     let cgroup_v1_relative_network = cgroups::network::relative_network::get_test_group();
     let seccomp = get_seccomp_test();
     let seccomp_notify = get_seccomp_notify_test();
+    let state = get_state_test();
     let ro_paths = get_ro_paths_test();
     let hostname = get_hostname_test();
     let misc_props = get_misc_props_test();
@@ -209,6 +211,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(cgroup_v1_relative_network));
     tm.add_test_group(Box::new(seccomp));
     tm.add_test_group(Box::new(seccomp_notify));
+    tm.add_test_group(Box::new(state));
     tm.add_test_group(Box::new(ro_paths));
     tm.add_test_group(Box::new(hostname));
     tm.add_test_group(Box::new(misc_props));

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -46,6 +46,7 @@ pub mod rootfs_propagation;
 pub mod scheduler;
 pub mod seccomp;
 pub mod seccomp_notify;
+pub mod state;
 pub mod sysctl;
 pub mod time_ns;
 pub mod tlb;

--- a/tests/contest/contest/src/tests/state/mod.rs
+++ b/tests/contest/contest/src/tests/state/mod.rs
@@ -1,0 +1,3 @@
+mod state_test;
+
+pub use state_test::get_state_test;

--- a/tests/contest/contest/src/tests/state/state_test.rs
+++ b/tests/contest/contest/src/tests/state/state_test.rs
@@ -1,0 +1,98 @@
+use std::process::{Command, Output};
+
+use anyhow::anyhow;
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::tests::lifecycle::ContainerLifecycle;
+use crate::utils::{State, get_runtime_path};
+
+fn run_state(container: &ContainerLifecycle, id: Option<&str>) -> std::io::Result<Output> {
+    let mut command = Command::new(get_runtime_path());
+    command
+        .arg("--root")
+        .arg(container.get_project_path().join("runtime"))
+        .arg("state");
+
+    if let Some(id) = id {
+        command.arg(id);
+    }
+
+    command.output()
+}
+
+fn state_without_id() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    match run_state(&container, None) {
+        Ok(output) if !output.status.success() => TestResult::Passed,
+        Ok(_) => TestResult::Failed(anyhow!(
+            "state without a container ID unexpectedly succeeded"
+        )),
+        Err(err) => TestResult::Failed(anyhow!("failed to execute state command: {err}")),
+    }
+}
+
+fn state_nonexistent_container() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    match run_state(&container, Some(container.get_id())) {
+        Ok(output) if !output.status.success() => TestResult::Passed,
+        Ok(_) => TestResult::Failed(anyhow!(
+            "state for a non-existent container unexpectedly succeeded"
+        )),
+        Err(err) => TestResult::Failed(anyhow!("failed to execute state command: {err}")),
+    }
+}
+
+fn state_created_container() -> TestResult {
+    let container = ContainerLifecycle::new();
+
+    if !matches!(container.create(), TestResult::Passed) {
+        return TestResult::Failed(anyhow!("failed to create container"));
+    }
+
+    let result = match run_state(&container, Some(container.get_id())) {
+        Ok(output) if output.status.success() => {
+            match serde_json::from_slice::<State>(&output.stdout) {
+                Ok(state) if state.id == container.get_id() && state.status == "created" => {
+                    TestResult::Passed
+                }
+                Ok(state) => TestResult::Failed(anyhow!(
+                    "unexpected container state: id={}, status={}",
+                    state.id,
+                    state.status
+                )),
+                Err(err) => TestResult::Failed(anyhow!(
+                    "failed to parse state output as OCI state JSON: {err}"
+                )),
+            }
+        }
+        Ok(output) => TestResult::Failed(anyhow!(
+            "state for a created container failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )),
+        Err(err) => TestResult::Failed(anyhow!("failed to execute state command: {err}")),
+    };
+
+    let cleanup = container.delete();
+    match result {
+        TestResult::Passed => cleanup,
+        _ => result,
+    }
+}
+
+pub fn get_state_test() -> TestGroup {
+    let mut test_group = TestGroup::new("state");
+    test_group.add(vec![
+        Box::new(Test::new("state_without_id", Box::new(state_without_id))),
+        Box::new(Test::new(
+            "state_nonexistent_container",
+            Box::new(state_nonexistent_container),
+        )),
+        Box::new(Test::new(
+            "state_created_container",
+            Box::new(state_created_container),
+        )),
+    ]);
+    test_group
+}

--- a/tests/contest/contest/src/tests/state/state_test.rs
+++ b/tests/contest/contest/src/tests/state/state_test.rs
@@ -1,6 +1,6 @@
 use std::process::{Command, Output};
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use test_framework::{Test, TestGroup, TestResult};
 
 use crate::tests::lifecycle::ContainerLifecycle;
@@ -47,8 +47,8 @@ fn state_nonexistent_container() -> TestResult {
 fn state_created_container() -> TestResult {
     let container = ContainerLifecycle::new();
 
-    if !matches!(container.create(), TestResult::Passed) {
-        return TestResult::Failed(anyhow!("failed to create container"));
+    if let TestResult::Failed(err) = container.create() {
+        return TestResult::Failed(err.context("failed to create container"));
     }
 
     let result = match run_state(&container, Some(container.get_id())) {

--- a/tests/contest/contest/src/tests/state/state_test.rs
+++ b/tests/contest/contest/src/tests/state/state_test.rs
@@ -1,6 +1,6 @@
 use std::process::{Command, Output};
 
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use test_framework::{Test, TestGroup, TestResult};
 
 use crate::tests::lifecycle::ContainerLifecycle;


### PR DESCRIPTION
## Summary

- port the OCI runtime-tools `state` validation into the Rust contest suite
- verify `state` fails without a container ID
- verify `state` fails for a non-existent container
- verify a created container returns parseable OCI state with the expected ID and status

Part of #361.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p contest` cannot complete on native Windows because the contest suite depends on Linux-only crates; Linux CI should validate the build.

Behavioral reference: `opencontainers/runtime-tools/validation/state`