### PR TITLE
feat: add support for `--blkio-weight` in `youki update`

### DIFF
--- a/crates/libcgroups/src/v2/io.rs
+++ b/crates/libcgroups/src/v2/io.rs
@@ -112,7 +112,8 @@ impl Io {
         if v == 0 {
             return 0;
         }
-        1 + (v.saturating_sub(10)) * 9999 / 990
+        // Widen before multiplying because the intermediate value may exceed u16.
+        (1 + (u32::from(v) - 10) * 9999 / 990) as u16
     }
 
     fn io_max_path(path: &Path) -> PathBuf {

--- a/crates/libcgroups/src/v2/io.rs
+++ b/crates/libcgroups/src/v2/io.rs
@@ -21,6 +21,8 @@ pub enum V2IoControllerError {
     WrappedIo(#[from] WrappedIoError),
     #[error("cannot set leaf_weight with cgroupv2")]
     LeafWeight,
+    #[error("invalid weight {0}: must be in range [10, 1000]")]
+    InvalidWeight(u16),
 }
 
 pub struct Io {}
@@ -138,9 +140,12 @@ impl Io {
             }
         }
         if let Some(io_weight) = blkio.weight() {
-            // be aligned with what runc does
-            // See also: https://github.com/opencontainers/runc/blob/81044ad7c902f3fc153cb8ffadaf4da62855193f/libcontainer/cgroups/fs2/io.go#L57-L69
-            if io_weight > 0 {
+            if io_weight != 0 {
+                if !(10..=1000).contains(&io_weight) {
+                    return Err(V2IoControllerError::InvalidWeight(io_weight));
+                }
+                // be aligned with what runc does
+                // See also: https://github.com/opencontainers/runc/blob/81044ad7c902f3fc153cb8ffadaf4da62855193f/libcontainer/cgroups/fs2/io.go#L57-L69
                 let cgroup_file = root_path.join(CGROUP_BFQ_IO_WEIGHT);
                 if cgroup_file.exists() {
                     common::write_cgroup_file(cgroup_file, io_weight)?;
@@ -342,6 +347,36 @@ mod test {
             Io::apply(tmp.path(), &blkio).expect("apply blkio");
             let content = fs::read_to_string(weight_file).expect("read blkio weight");
             assert_eq!(case.expected_weight, content);
+        }
+    }
+
+    #[test]
+    fn test_set_ioweight_zero_is_noop() {
+        for cgroup_file in [CGROUP_BFQ_IO_WEIGHT, CGROUP_IO_WEIGHT] {
+            let (tmp, weight_file) = setup(cgroup_file);
+            set_fixture(tmp.path(), cgroup_file, "100").unwrap();
+            let blkio = LinuxBlockIoBuilder::default().weight(0u16).build().unwrap();
+
+            Io::apply(tmp.path(), &blkio).expect("weight 0 must succeed as no-op");
+            let content = fs::read_to_string(weight_file).expect("read blkio weight");
+            assert_eq!("100", content);
+        }
+    }
+
+    #[test]
+    fn test_set_ioweight_rejects_out_of_range() {
+        for weight in [1u16, 9, 1001, 2000] {
+            let (tmp, _) = setup(CGROUP_BFQ_IO_WEIGHT);
+            let blkio = LinuxBlockIoBuilder::default()
+                .weight(weight)
+                .build()
+                .unwrap();
+
+            let err = Io::apply(tmp.path(), &blkio).expect_err("weight must be rejected");
+            assert!(
+                matches!(err, V2IoControllerError::InvalidWeight(v) if v == weight),
+                "unexpected error for weight {weight}: {err:?}"
+            );
         }
     }
 

--- a/crates/youki/src/commands/update.rs
+++ b/crates/youki/src/commands/update.rs
@@ -1,10 +1,12 @@
 use std::path::PathBuf;
 use std::{fs, io};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use libcgroups::common::{CgroupManager, ControllerOpt};
 use libcgroups::{self};
-use libcontainer::oci_spec::runtime::{LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder};
+use libcontainer::oci_spec::runtime::{
+    LinuxBlockIoBuilder, LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder,
+};
 use liboci_cli::Update;
 
 use crate::commands::create_cgroup_manager;
@@ -23,6 +25,17 @@ pub fn update(args: Update, root_path: PathBuf) -> Result<()> {
         };
     } else {
         let mut builder = LinuxResourcesBuilder::default();
+        if let Some(blkio_weight) = args.blkio_weight {
+            if !(10..=1000).contains(&blkio_weight) {
+                bail!(
+                    "invalid value {blkio_weight} for --blkio-weight, expected value in range [10, 1000]"
+                );
+            }
+            let blkio = LinuxBlockIoBuilder::default()
+                .weight(blkio_weight as u16)
+                .build()?;
+            builder = builder.block_io(blkio);
+        }
         if let Some(new_pids_limit) = args.pids_limit {
             builder = builder.pids(LinuxPidsBuilder::default().limit(new_pids_limit).build()?);
         }

--- a/crates/youki/src/commands/update.rs
+++ b/crates/youki/src/commands/update.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::{fs, io};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result};
 use libcgroups::common::{CgroupManager, ControllerOpt};
 use libcgroups::{self};
 use libcontainer::oci_spec::runtime::{
@@ -25,15 +25,12 @@ pub fn update(args: Update, root_path: PathBuf) -> Result<()> {
         };
     } else {
         let mut builder = LinuxResourcesBuilder::default();
-        if let Some(blkio_weight) = args.blkio_weight {
-            if !(10..=1000).contains(&blkio_weight) {
-                bail!(
-                    "invalid value {blkio_weight} for --blkio-weight, expected value in range [10, 1000]"
-                );
-            }
-            let blkio = LinuxBlockIoBuilder::default()
-                .weight(blkio_weight as u16)
-                .build()?;
+        if let Some(blkio_weight) = args.blkio_weight
+            && blkio_weight != 0
+        {
+            let weight = u16::try_from(blkio_weight)
+                .with_context(|| format!("invalid value {blkio_weight} for --blkio-weight"))?;
+            let blkio = LinuxBlockIoBuilder::default().weight(weight).build()?;
             builder = builder.block_io(blkio);
         }
         if let Some(new_pids_limit) = args.pids_limit {

--- a/tests/contest/contest/src/tests/update/blkio.rs
+++ b/tests/contest/contest/src/tests/update/blkio.rs
@@ -7,7 +7,7 @@ use oci_spec::runtime::{
 };
 use test_framework::{TestResult, test_result};
 
-use super::{check_cgroup_value, update_container_and_wait};
+use super::update_container_and_wait;
 use crate::utils::test_utils::check_container_created;
 use crate::utils::{
     start_container, test_outside_container, update_container, update_container_with_stdin,
@@ -38,30 +38,31 @@ fn convert_blkio_weight_to_io_weight(weight: u16) -> u64 {
     1 + (u64::from(weight) - 10) * 9999 / 990
 }
 
+// Both files may prefix the default weight with "default" and may contain
+// per-device entries, so match the expected numeric value among the tokens.
 fn check_blkio_weight(cgroup_path: &Path, weight: u16) -> Result<()> {
     let bfq_path = cgroup_path.join("io.bfq.weight");
-    if bfq_path.exists() {
-        let content = fs::read_to_string(&bfq_path)
-            .with_context(|| format!("failed to read {}", bfq_path.display()))?;
-        if !content
-            .split_whitespace()
-            .any(|token| token == weight.to_string())
-        {
-            bail!(
-                "{}: expected weight {}, got {:?}",
-                bfq_path.display(),
-                weight,
-                content
-            );
-        }
-        Ok(())
+    let (path, expected) = if bfq_path.exists() {
+        (bfq_path, weight.to_string())
     } else {
-        check_cgroup_value(
-            cgroup_path,
-            "io.weight",
-            &convert_blkio_weight_to_io_weight(weight).to_string(),
+        (
+            cgroup_path.join("io.weight"),
+            convert_blkio_weight_to_io_weight(weight).to_string(),
         )
+    };
+
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    if !content.split_whitespace().any(|token| token == expected) {
+        bail!(
+            "{}: expected weight {}, got {:?}",
+            path.display(),
+            expected,
+            content
+        );
     }
+
+    Ok(())
 }
 
 fn expect_update_failure(id: &str, dir: &Path, weight: &str) -> Result<()> {

--- a/tests/contest/contest/src/tests/update/blkio.rs
+++ b/tests/contest/contest/src/tests/update/blkio.rs
@@ -51,8 +51,8 @@ fn check_blkio_weight(cgroup_path: &Path, weight: u16) -> Result<()> {
         )
     };
 
-    let content = fs::read_to_string(&path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
     if !content.split_whitespace().any(|token| token == expected) {
         bail!(
             "{}: expected weight {}, got {:?}",

--- a/tests/contest/contest/src/tests/update/blkio.rs
+++ b/tests/contest/contest/src/tests/update/blkio.rs
@@ -1,0 +1,138 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow, bail};
+use oci_spec::runtime::{
+    LinuxBlockIoBuilder, LinuxResources, LinuxResourcesBuilder, ProcessBuilder, Spec, SpecBuilder,
+};
+use test_framework::{TestResult, test_result};
+
+use super::{check_cgroup_value, update_container_and_wait};
+use crate::utils::test_utils::check_container_created;
+use crate::utils::{
+    start_container, test_outside_container, update_container, update_container_with_stdin,
+};
+
+const INITIAL_WEIGHT: u16 = 100;
+const UPDATED_WEIGHT: u16 = 500;
+
+fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<Spec> {
+    let mut spec = SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["sleep".to_string(), "1000".to_string()])
+                .build()?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    if let Some(linux) = spec.linux_mut() {
+        linux.set_cgroups_path(Some(Path::new("/runtime-test").join(cgroup_name)));
+        linux.set_resources(resources);
+    }
+
+    Ok(spec)
+}
+
+fn convert_blkio_weight_to_io_weight(weight: u16) -> u64 {
+    1 + (u64::from(weight) - 10) * 9999 / 990
+}
+
+fn check_blkio_weight(cgroup_path: &Path, weight: u16) -> Result<()> {
+    let bfq_path = cgroup_path.join("io.bfq.weight");
+    if bfq_path.exists() {
+        let content = fs::read_to_string(&bfq_path)
+            .with_context(|| format!("failed to read {}", bfq_path.display()))?;
+        if !content
+            .split_whitespace()
+            .any(|token| token == weight.to_string())
+        {
+            bail!(
+                "{}: expected weight {}, got {:?}",
+                bfq_path.display(),
+                weight,
+                content
+            );
+        }
+        Ok(())
+    } else {
+        check_cgroup_value(
+            cgroup_path,
+            "io.weight",
+            &convert_blkio_weight_to_io_weight(weight).to_string(),
+        )
+    }
+}
+
+fn expect_update_failure(id: &str, dir: &Path, weight: &str) -> Result<()> {
+    let status = update_container(id, dir, &["--blkio-weight", weight])
+        .unwrap()
+        .wait()
+        .unwrap();
+
+    if status.success() {
+        bail!("expected --blkio-weight {weight} to fail, but it succeeded");
+    }
+
+    Ok(())
+}
+
+// "update cgroup blkio weight"
+pub(crate) fn update_blkio_weight_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_blkio_weight";
+    let block_io = test_result!(
+        LinuxBlockIoBuilder::default()
+            .weight(INITIAL_WEIGHT)
+            .build()
+            .context("failed to build blockio resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .block_io(block_io)
+            .build()
+            .context("failed to build resources spec")
+    );
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        // check the initial value was properly set
+        test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
+
+        // Update blkio weight via CLI flag.
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--blkio-weight", "500"],
+        ));
+        test_result!(check_blkio_weight(&cgroup_path, UPDATED_WEIGHT));
+
+        // Revert to the test initial value via json on stdin
+        let json = serde_json::json!({ "blockIO": { "weight": INITIAL_WEIGHT } }).to_string();
+        let update_result = update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        if !update_result.success() {
+            return TestResult::Failed(anyhow!("update blkio weight via stdin failed"));
+        }
+        test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
+
+        // Out of range values must be rejected and leave the weight unchanged.
+        test_result!(expect_update_failure(id, dir, "2000"));
+        test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
+
+        TestResult::Passed
+    })
+}

--- a/tests/contest/contest/src/tests/update/blkio.rs
+++ b/tests/contest/contest/src/tests/update/blkio.rs
@@ -13,7 +13,7 @@ use crate::utils::{
     start_container, test_outside_container, update_container, update_container_with_stdin,
 };
 
-const INITIAL_WEIGHT: u16 = 100;
+const INITIAL_WEIGHT: u16 = 200;
 const UPDATED_WEIGHT: u16 = 500;
 
 fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<Spec> {
@@ -130,7 +130,13 @@ pub(crate) fn update_blkio_weight_test() -> TestResult {
         }
         test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
 
+        // Updating to 0 must succeed and leave the value unchanged.
+        test_result!(update_container_and_wait(id, dir, &["--blkio-weight", "0"]));
+        test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
+
         // Out of range values must be rejected and leave the weight unchanged.
+        test_result!(expect_update_failure(id, dir, "5"));
+        test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
         test_result!(expect_update_failure(id, dir, "2000"));
         test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
 

--- a/tests/contest/contest/src/tests/update/blkio.rs
+++ b/tests/contest/contest/src/tests/update/blkio.rs
@@ -10,7 +10,8 @@ use test_framework::{TestResult, test_result};
 use super::update_container_and_wait;
 use crate::utils::test_utils::check_container_created;
 use crate::utils::{
-    start_container, test_outside_container, update_container, update_container_with_stdin,
+    is_runtime_youki, start_container, test_outside_container, update_container,
+    update_container_with_stdin,
 };
 
 const INITIAL_WEIGHT: u16 = 200;
@@ -135,10 +136,14 @@ pub(crate) fn update_blkio_weight_test() -> TestResult {
         test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
 
         // Out of range values must be rejected and leave the weight unchanged.
-        test_result!(expect_update_failure(id, dir, "5"));
-        test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
-        test_result!(expect_update_failure(id, dir, "2000"));
-        test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
+        // youki enforces OCI spec range [10, 1000] in libcgroups; runc
+        // delegates to the kernel (io.bfq.weight allows [1, 10000]).
+        if is_runtime_youki() {
+            test_result!(expect_update_failure(id, dir, "5"));
+            test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
+            test_result!(expect_update_failure(id, dir, "2000"));
+            test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
+        }
 
         TestResult::Passed
     })

--- a/tests/contest/contest/src/tests/update/blkio.rs
+++ b/tests/contest/contest/src/tests/update/blkio.rs
@@ -9,10 +9,7 @@ use test_framework::{TestResult, test_result};
 
 use super::update_container_and_wait;
 use crate::utils::test_utils::check_container_created;
-use crate::utils::{
-    is_runtime_youki, start_container, test_outside_container, update_container,
-    update_container_with_stdin,
-};
+use crate::utils::{start_container, test_outside_container, update_container_with_stdin};
 
 const INITIAL_WEIGHT: u16 = 200;
 const UPDATED_WEIGHT: u16 = 500;
@@ -61,19 +58,6 @@ fn check_blkio_weight(cgroup_path: &Path, weight: u16) -> Result<()> {
             expected,
             content
         );
-    }
-
-    Ok(())
-}
-
-fn expect_update_failure(id: &str, dir: &Path, weight: &str) -> Result<()> {
-    let status = update_container(id, dir, &["--blkio-weight", weight])
-        .unwrap()
-        .wait()
-        .unwrap();
-
-    if status.success() {
-        bail!("expected --blkio-weight {weight} to fail, but it succeeded");
     }
 
     Ok(())
@@ -134,16 +118,6 @@ pub(crate) fn update_blkio_weight_test() -> TestResult {
         // Updating to 0 must succeed and leave the value unchanged.
         test_result!(update_container_and_wait(id, dir, &["--blkio-weight", "0"]));
         test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
-
-        // Out of range values must be rejected and leave the weight unchanged.
-        // youki enforces OCI spec range [10, 1000] in libcgroups; runc
-        // delegates to the kernel (io.bfq.weight allows [1, 10000]).
-        if is_runtime_youki() {
-            test_result!(expect_update_failure(id, dir, "5"));
-            test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
-            test_result!(expect_update_failure(id, dir, "2000"));
-            test_result!(check_blkio_weight(&cgroup_path, INITIAL_WEIGHT));
-        }
 
         TestResult::Passed
     })

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -1,3 +1,4 @@
+mod blkio;
 mod common;
 mod cpu;
 mod cpuset;
@@ -107,6 +108,22 @@ fn can_run_cpuset_range_update() -> bool {
     can_run_cpuset() && cpu_count() > 8
 }
 
+fn can_run_blkio_update() -> bool {
+    if !is_cgroup_v2() {
+        return false;
+    }
+
+    let controllers_result = libcgroups::v2::util::get_available_controllers(DEFAULT_CGROUP_ROOT);
+    if controllers_result.is_err() {
+        return false;
+    }
+
+    controllers_result
+        .unwrap()
+        .into_iter()
+        .any(|controller| controller == ControllerType::Io)
+}
+
 pub fn get_update_test() -> TestGroup {
     let mut test_group = TestGroup::new("update");
 
@@ -126,6 +143,12 @@ pub fn get_update_test() -> TestGroup {
         "update_pids_limit_test",
         Box::new(can_run_update),
         Box::new(pids_limit::update_pids_limit_test),
+    );
+
+    let update_blkio_weight_test = ConditionalTest::new(
+        "update_blkio_weight_test",
+        Box::new(can_run_blkio_update),
+        Box::new(blkio::update_blkio_weight_test),
     );
 
     let cpu_burst_test = ConditionalTest::new(
@@ -198,6 +221,7 @@ pub fn get_update_test() -> TestGroup {
         Box::new(update_cgroup_v2_common_limits_test),
         Box::new(update_cpu_limits_test),
         Box::new(update_pids_limit_test),
+        Box::new(update_blkio_weight_test),
         Box::new(cpu_burst_test),
         Box::new(set_cpu_period_without_quota_test),
         Box::new(set_cpu_period_without_quota_invalid_test),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3679

## Additional Context
<!-- Add any other context about the pull request here -->

I've written the test by reading [crates/libcgroups/src/v2/io.rs#L139](https://github.com/youki-dev/youki/blob/main/crates/libcgroups/src/v2/io.rs#L140) please correct me if my understanding is wrong here.