### PR TITLE
test(utils): Add normalize method unit test in libcontainer/utils.rs

### DIFF
--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -95,7 +95,6 @@ impl PathBufExt for Path {
     // adapted from https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
     fn normalize(&self) -> PathBuf {
         let mut components = self.components().peekable();
-
         let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
             components.next();
             PathBuf::from(c.as_os_str())

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -705,21 +705,19 @@ mod tests {
             ("/a/b/c", "/a/b/c"),
             ("/a/./b", "/a/b"),
             ("/a/b/../c", "/a/c"),
-            ("/proc/self/../1", "/proc/1"),
-            
+            ("/asd/dfg/../gjoi", "/asd/gjoi"),
             // paths processed first by components()
             ("/a/b/", "/a/b"),
             ("/a//b", "/a/b"),
-
             // relative paths
             ("", ""),
             (".", ""),
             ("..", ""),
+            // Leading '..' is just dropped under current logic, leaving only 'a'
             ("../a", "a"),
             ("a/../../b", "b"),
             ("./a/b", "a/b"),
             ("a/b/../..", ""),
-            
             // root escape check
             ("/..", "/"),
             ("/../..", "/"),

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -711,7 +711,6 @@ mod tests {
             ("", ""),
             (".", ""),
             ("..", ""),
-            // Leading '..' is just dropped under current logic, leaving only 'a'
             ("../a", "a"),
             ("a/../../b", "b"),
             ("./a/b", "a/b"),

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -96,7 +96,6 @@ impl PathBufExt for Path {
     fn normalize(&self) -> PathBuf {
         let mut components = self.components().peekable();
 
-        // Check if the path has Windows prefix
         let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
             components.next();
             PathBuf::from(c.as_os_str())

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -95,6 +95,8 @@ impl PathBufExt for Path {
     // adapted from https://github.com/rust-lang/cargo/blob/fede83ccf973457de319ba6fa0e36ead454d2e20/src/cargo/util/paths.rs#L61
     fn normalize(&self) -> PathBuf {
         let mut components = self.components().peekable();
+
+        // Check if the path has Windows prefix
         let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
             components.next();
             PathBuf::from(c.as_os_str())
@@ -692,5 +694,39 @@ mod tests {
         assert!(
             matches!(result, Err(VerifyInodeError::Verification(error_message)) if error_message == "error")
         )
+    }
+
+    #[test]
+    fn test_normalize_path() {
+        // This test checks a path normalization method
+
+        let cases = [
+            // ordinary paths
+            ("/a/b/c", "/a/b/c"),
+            ("/a/./b", "/a/b"),
+            ("/a/b/../c", "/a/c"),
+            ("/proc/self/../1", "/proc/1"),
+            
+            // paths processed first by components()
+            ("/a/b/", "/a/b"),
+            ("/a//b", "/a/b"),
+
+            // relative paths
+            ("", ""),
+            (".", ""),
+            ("..", ""),
+            ("../a", "a"),
+            ("a/../../b", "b"),
+            ("./a/b", "a/b"),
+            ("a/b/../..", ""),
+            
+            // root escape check
+            ("/..", "/"),
+            ("/../..", "/"),
+            ("/a/../../b", "/b"),
+        ];
+        for (input, answer) in cases {
+            assert_eq!(Path::new(input).normalize(), Path::new(answer));
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
- The normalize() method in utils.rs has no unit tests at all.
- To improve test coverage and prevent malfunctioning behavior when using the normalize method, add a normalize method unit test with several path cases.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Refer to #279 

## Additional Context
<!-- Add any other context about the pull request here -->
