### PR TITLE
grouping netlink

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
         patterns:
           - "wasmtime"
           - "wasi-common"
+      netlink:
+        patterns:
+          - "netlink-packet-core"
+          - "netlink-packet-route"
+          - "netlink-sys"
       patch:
         update-types: 
         - patch


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This change is to allow us to merge Dependabot PRs for `netlink`.

https://github.com/youki-dev/youki/pull/3705
https://github.com/youki-dev/youki/pull/3703
https://github.com/youki-dev/youki/pull/3702

Since Dependabot creates separate PRs for the `netlink`-related dependencies, the CI fails when they are updated independently.
To avoid this, we group them together, as we already do for `wasm` (https://github.com/youki-dev/youki/pull/3511).

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
